### PR TITLE
[Feature] Allow Eloquent schemas to serialize models to resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ All notable changes to this project will be documented in this file. This projec
 Eloquent fields now support serializing models to JSON values. This means that resource classes
 now become optional: because in the absence of a resource class, the implementation can fall-back
 on serializing resources using the Eloquent schema.
+- **BREAKING** Split the `Arr` field class into two: `ArrayList` and `ArrayHash`. This
+was required because now that the fields are also serializing values, the handling of empty values
+is different depending on whether it is a list (empty array) or a hash (empty array converted
+to `null`).
 
 ## [1.0.0-alpha.1] - 2021-01-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file. This project adheres to
 [Semantic Versioning](http://semver.org/) and [this changelog format](http://keepachangelog.com/).
 
+## Unreleased
+
+### Added
+- [#1](https://github.com/laravel-json-api/eloquent/pull/1)
+Eloquent fields now support serializing models to JSON values. This means that resource classes
+now become optional: because in the absence of a resource class, the implementation can fall-back
+on serializing resources using the Eloquent schema.
+
 ## [1.0.0-alpha.1] - 2021-01-25
 
 Initial release.

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "ext-json": "*",
         "illuminate/database": "^8.0",
         "illuminate/support": "^8.0",
-        "laravel-json-api/core": "^1.0@alpha"
+        "laravel-json-api/core": "dev-feature/schema-resources"
     },
     "require-dev": {
         "orchestra/testbench": "^6.9",

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "ext-json": "*",
         "illuminate/database": "^8.0",
         "illuminate/support": "^8.0",
-        "laravel-json-api/core": "dev-feature/schema-resources"
+        "laravel-json-api/core": "^1.0.0-alpha.2"
     },
     "require-dev": {
         "orchestra/testbench": "^6.9",
@@ -50,7 +50,7 @@
             "dev-develop": "1.x-dev"
         }
     },
-    "minimum-stability": "stable",
+    "minimum-stability": "dev",
     "prefer-stable": true,
     "config": {
         "sort-packages": true

--- a/src/Fields/ArrayList.php
+++ b/src/Fields/ArrayList.php
@@ -1,0 +1,99 @@
+<?php
+/*
+ * Copyright 2021 Cloud Creativity Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+declare(strict_types=1);
+
+namespace LaravelJsonApi\Eloquent\Fields;
+
+use Illuminate\Support\Arr;
+use function is_null;
+use function sort;
+
+class ArrayList extends Attribute
+{
+
+    /**
+     * @var bool
+     */
+    private bool $sorted = false;
+
+    /**
+     * Create an array attribute.
+     *
+     * @param string $fieldName
+     * @param string|null $column
+     * @return ArrayList
+     */
+    public static function make(string $fieldName, string $column = null): self
+    {
+        return new self($fieldName, $column);
+    }
+
+    /**
+     * Sort values when deserializing the array.
+     *
+     * @return $this
+     */
+    public function sorted(): self
+    {
+        $this->sorted = true;
+
+        return $this;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function serialize(object $model)
+    {
+        $value = parent::serialize($model);
+
+        if ($value && $this->sorted) {
+            sort($value);
+        }
+
+        return $value ? array_values($value) : $value;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function deserialize($value)
+    {
+        $value = parent::deserialize($value);
+
+        if ($value && $this->sorted) {
+            sort($value);
+        }
+
+        return $value;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function assertValue($value): void
+    {
+        if ((!is_null($value) && !is_array($value)) || (!empty($value) && Arr::isAssoc($value))) {
+            throw new \UnexpectedValueException(sprintf(
+                'Expecting the value of attribute %s to be an array list.',
+                $this->name()
+            ));
+        }
+    }
+
+}

--- a/src/Fields/Concerns/Hideable.php
+++ b/src/Fields/Concerns/Hideable.php
@@ -1,0 +1,71 @@
+<?php
+/*
+ * Copyright 2021 Cloud Creativity Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+declare(strict_types=1);
+
+namespace LaravelJsonApi\Eloquent\Fields\Concerns;
+
+use Closure;
+use Illuminate\Http\Request;
+
+trait Hideable
+{
+
+    /**
+     * @var Closure|bool
+     */
+    private $hidden = false;
+
+    /**
+     * Mark the field as hidden.
+     *
+     * @param Closure|null $callback
+     * @return $this
+     */
+    public function hidden(Closure $callback = null): self
+    {
+        $this->hidden = $callback ?: true;
+
+        return $this;
+    }
+
+    /**
+     * Is the field hidden?
+     *
+     * @param Request|null $request
+     * @return bool
+     */
+    public function isHidden($request): bool
+    {
+        if (is_callable($this->hidden)) {
+            return true === ($this->hidden)($request);
+        }
+
+        return true === $this->hidden;
+    }
+
+    /**
+     * Is the field not hidden?
+     *
+     * @param Request|null $request
+     * @return bool
+     */
+    public function isNotHidden($request): bool
+    {
+        return !$this->isHidden($request);
+    }
+}

--- a/src/Fields/ID.php
+++ b/src/Fields/ID.php
@@ -82,6 +82,14 @@ class ID implements IDContract, Fillable
     /**
      * @inheritDoc
      */
+    public function key(): ?string
+    {
+        return $this->column();
+    }
+
+    /**
+     * @inheritDoc
+     */
     public function isSparseField(): bool
     {
         return false;

--- a/src/Schema.php
+++ b/src/Schema.php
@@ -22,7 +22,6 @@ namespace LaravelJsonApi\Eloquent;
 use Illuminate\Database\Eloquent\Model;
 use LaravelJsonApi\Contracts\Store\Repository as RepositoryContract;
 use LaravelJsonApi\Core\Schema\Schema as BaseSchema;
-use LaravelJsonApi\Eloquent\Fields\ID;
 use LaravelJsonApi\Eloquent\Fields\Relations\ToMany;
 use LaravelJsonApi\Eloquent\Fields\Relations\ToOne;
 use LogicException;
@@ -96,6 +95,14 @@ abstract class Schema extends BaseSchema
     }
 
     /**
+     * @return string|null
+     */
+    public function idKeyName(): ?string
+    {
+        return $this->idColumn();
+    }
+
+    /**
      * @return string
      */
     public function idColumn(): string
@@ -104,10 +111,8 @@ abstract class Schema extends BaseSchema
             return $this->idColumn;
         }
 
-        $id = $this->id();
-
-        if ($id instanceof ID && $col = $id->column()) {
-            return $this->idColumn = $col;
+        if ($key = $this->id()->key()) {
+            return $this->idColumn = $key;
         }
 
         return $this->idColumn = $this->newInstance()->getRouteKeyName();

--- a/tests/lib/Integration/Fields/ArrTest.php
+++ b/tests/lib/Integration/Fields/ArrTest.php
@@ -38,6 +38,9 @@ class ArrTest extends TestCase
         $this->assertSame(['access_permissions'], $attr->columnsForField());
         $this->assertFalse($attr->isSortable());
         $this->assertFalse($attr->isReadOnly($request));
+        $this->assertTrue($attr->isNotReadOnly($request));
+        $this->assertFalse($attr->isHidden($request));
+        $this->assertTrue($attr->isNotHidden($request));
     }
 
     public function testColumn(): void

--- a/tests/lib/Integration/Fields/ArrayHashTest.php
+++ b/tests/lib/Integration/Fields/ArrayHashTest.php
@@ -182,21 +182,24 @@ class ArrayHashTest extends TestCase
         $this->assertSame(['foo' => 'bazbat', 'bar' => 'foobar'], $model->permissions);
     }
 
-    public function testSortedKeys(): void
+    public function testSortKeys(): void
     {
         $model = new Role();
-        $attr = ArrayHash::make('permissions')->sortedKeys();
+        $attr = ArrayHash::make('permissions')->sortKeys();
 
         $attr->fill($model, ['foo' => 'bar', 'baz' => 'bat']);
         $this->assertSame(['baz' => 'bat', 'foo' => 'bar'], $model->permissions);
     }
 
-    public function testCamelize(): void
+    public function testUnderscoreToCamel(): void
     {
         $model = new Role();
-        $attr = ArrayHash::make('permissions')->camelize();
 
-        $attr->fill($model, [
+        $attr = ArrayHash::make('permissions')
+            ->underscoreFields()
+            ->camelizeKeys();
+
+        $attr->fill($model, $json = [
             'foo_bar' => 'foobar',
             'baz_bat' => 'bazbat',
         ]);
@@ -205,14 +208,19 @@ class ArrayHashTest extends TestCase
             'fooBar' => 'foobar',
             'bazBat' => 'bazbat',
         ], $model->permissions);
+
+        $this->assertSame($json, $attr->serialize($model)->jsonSerialize());
     }
 
-    public function testDasherize(): void
+    public function testUnderscoreToDash(): void
     {
         $model = new Role();
-        $attr = ArrayHash::make('permissions')->dasherize();
 
-        $attr->fill($model, [
+        $attr = ArrayHash::make('permissions')
+            ->underscoreFields()
+            ->dasherizeKeys();
+
+        $attr->fill($model, $json = [
             'foo_bar' => 'foobar',
             'baz_bat' => 'bazbat',
         ]);
@@ -221,14 +229,124 @@ class ArrayHashTest extends TestCase
             'foo-bar' => 'foobar',
             'baz-bat' => 'bazbat',
         ], $model->permissions);
+
+        $this->assertSame($json, $attr->serialize($model)->jsonSerialize());
     }
 
-    public function testSnake(): void
+    public function testSnakeToCamel(): void
     {
         $model = new Role();
-        $attr = ArrayHash::make('permissions')->snake();
 
-        $attr->fill($model, [
+        $attr = ArrayHash::make('permissions')
+            ->snakeFields()
+            ->camelizeKeys();
+
+        $attr->fill($model, $json = [
+            'foo_bar' => 'foobar',
+            'baz_bat' => 'bazbat',
+        ]);
+
+        $this->assertSame([
+            'fooBar' => 'foobar',
+            'bazBat' => 'bazbat',
+        ], $model->permissions);
+
+        $this->assertSame($json, $attr->serialize($model)->jsonSerialize());
+    }
+
+    public function testSnakeToDash(): void
+    {
+        $model = new Role();
+
+        $attr = ArrayHash::make('permissions')
+            ->snakeFields()
+            ->dasherizeKeys();
+
+        $attr->fill($model, $json = [
+            'foo_bar' => 'foobar',
+            'baz_bat' => 'bazbat',
+        ]);
+
+        $this->assertSame([
+            'foo-bar' => 'foobar',
+            'baz-bat' => 'bazbat',
+        ], $model->permissions);
+
+        $this->assertSame($json, $attr->serialize($model)->jsonSerialize());
+    }
+
+    public function testDashToCamel(): void
+    {
+        $model = new Role();
+
+        $attr = ArrayHash::make('permissions')
+            ->dasherizeFields()
+            ->camelizeKeys();
+
+        $attr->fill($model, $json = [
+            'foo-bar' => 'foobar',
+            'baz-bat' => 'bazbat',
+        ]);
+
+        $this->assertSame([
+            'fooBar' => 'foobar',
+            'bazBat' => 'bazbat',
+        ], $model->permissions);
+
+        $this->assertSame($json, $attr->serialize($model)->jsonSerialize());
+    }
+
+    public function testDashToUnderscore(): void
+    {
+        $model = new Role();
+
+        $attr = ArrayHash::make('permissions')
+            ->dasherizeFields()
+            ->underscoreKeys();
+
+        $attr->fill($model, $json = [
+            'foo-bar' => 'foobar',
+            'baz-bat' => 'bazbat',
+        ]);
+
+        $this->assertSame([
+            'foo_bar' => 'foobar',
+            'baz_bat' => 'bazbat',
+        ], $model->permissions);
+
+        $this->assertSame($json, $attr->serialize($model)->jsonSerialize());
+    }
+
+    public function testDashToSnake(): void
+    {
+        $model = new Role();
+
+        $attr = ArrayHash::make('permissions')
+            ->dasherizeFields()
+            ->snakeKeys();
+
+        $attr->fill($model, $json = [
+            'foo-bar' => 'foobar',
+            'baz-bat' => 'bazbat',
+        ]);
+
+        $this->assertSame([
+            'foo_bar' => 'foobar',
+            'baz_bat' => 'bazbat',
+        ], $model->permissions);
+
+        $this->assertSame($json, $attr->serialize($model)->jsonSerialize());
+    }
+
+    public function testCamelToUnderscore(): void
+    {
+        $model = new Role();
+
+        $attr = ArrayHash::make('permissions')
+            ->camelizeFields()
+            ->underscoreKeys();
+
+        $attr->fill($model, $json = [
             'fooBar' => 'foobar',
             'bazBat' => 'bazbat',
         ]);
@@ -237,14 +355,19 @@ class ArrayHashTest extends TestCase
             'foo_bar' => 'foobar',
             'baz_bat' => 'bazbat',
         ], $model->permissions);
+
+        $this->assertSame($json, $attr->serialize($model)->jsonSerialize());
     }
 
-    public function testUnderscore(): void
+    public function testCamelToSnake(): void
     {
         $model = new Role();
-        $attr = ArrayHash::make('permissions')->underscore();
 
-        $attr->fill($model, [
+        $attr = ArrayHash::make('permissions')
+            ->camelizeFields()
+            ->snakeKeys();
+
+        $attr->fill($model, $json = [
             'fooBar' => 'foobar',
             'bazBat' => 'bazbat',
         ]);
@@ -253,6 +376,29 @@ class ArrayHashTest extends TestCase
             'foo_bar' => 'foobar',
             'baz_bat' => 'bazbat',
         ], $model->permissions);
+
+        $this->assertSame($json, $attr->serialize($model)->jsonSerialize());
+    }
+
+    public function testCamelToDash(): void
+    {
+        $model = new Role();
+
+        $attr = ArrayHash::make('permissions')
+            ->camelizeFields()
+            ->dasherizeKeys();
+
+        $attr->fill($model, $json = [
+            'fooBar' => 'foobar',
+            'bazBat' => 'bazbat',
+        ]);
+
+        $this->assertSame([
+            'foo-bar' => 'foobar',
+            'baz-bat' => 'bazbat',
+        ], $model->permissions);
+
+        $this->assertSame($json, $attr->serialize($model)->jsonSerialize());
     }
 
     public function testReadOnly(): void
@@ -321,7 +467,7 @@ class ArrayHashTest extends TestCase
 
         $attr = ArrayHash::make('permissions');
 
-        $this->assertSame($expected, $attr->serialize($model));
+        $this->assertSame($expected, $attr->serialize($model)->jsonSerialize());
     }
 
     public function testSerializeUsing(): void
@@ -333,7 +479,10 @@ class ArrayHashTest extends TestCase
             return ['baz' => 'bat'];
         });
 
-        $this->assertSame(['baz' => 'bat'], $attr->serialize($model));
+        $this->assertSame(
+            ['baz' => 'bat'],
+            $attr->serialize($model)->jsonSerialize()
+        );
     }
 
     public function testSerializeSorted(): void
@@ -342,16 +491,22 @@ class ArrayHashTest extends TestCase
 
         $attr = ArrayHash::make('permissions')->sorted();
 
-        $this->assertSame(['b' => 'bar', 'a' => 'foo'], $attr->serialize($model));
+        $this->assertSame(
+            ['b' => 'bar', 'a' => 'foo'],
+            $attr->serialize($model)->jsonSerialize()
+        );
     }
 
     public function testSerializeSortedKeys(): void
     {
         $model = new Role(['permissions' => ['foo' => 'a', 'bar' => 'b']]);
 
-        $attr = ArrayHash::make('permissions')->sortedKeys();
+        $attr = ArrayHash::make('permissions')->sortKeys();
 
-        $this->assertSame(['bar' => 'b', 'foo' => 'a'], $attr->serialize($model));
+        $this->assertSame(
+            ['bar' => 'b', 'foo' => 'a'],
+            $attr->serialize($model)->jsonSerialize()
+        );
     }
 
     public function testHidden(): void

--- a/tests/lib/Integration/Fields/ArrayListTest.php
+++ b/tests/lib/Integration/Fields/ArrayListTest.php
@@ -1,0 +1,299 @@
+<?php
+/*
+ * Copyright 2021 Cloud Creativity Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+declare(strict_types=1);
+
+namespace LaravelJsonApi\Eloquent\Tests\Integration\Fields;
+
+use App\Models\Role;
+use Illuminate\Http\Request;
+use LaravelJsonApi\Eloquent\Fields\ArrayList;
+use LaravelJsonApi\Eloquent\Tests\Integration\TestCase;
+
+class ArrayListTest extends TestCase
+{
+
+    public function test(): void
+    {
+        $request = $this->createMock(Request::class);
+        $attr = ArrayList::make('accessPermissions');
+
+        $this->assertSame('accessPermissions', $attr->name());
+        $this->assertSame('access_permissions', $attr->column());
+        $this->assertTrue($attr->isSparseField());
+        $this->assertSame(['access_permissions'], $attr->columnsForField());
+        $this->assertFalse($attr->isSortable());
+        $this->assertFalse($attr->isReadOnly($request));
+        $this->assertTrue($attr->isNotReadOnly($request));
+        $this->assertFalse($attr->isHidden($request));
+        $this->assertTrue($attr->isNotHidden($request));
+    }
+
+    public function testColumn(): void
+    {
+        $attr = ArrayList::make('permissions', 'access_permissions');
+
+        $this->assertSame('permissions', $attr->name());
+        $this->assertSame('access_permissions', $attr->column());
+        $this->assertSame(['access_permissions'], $attr->columnsForField());
+    }
+
+    public function testNotSparseField(): void
+    {
+        $attr = ArrayList::make('permissions')->notSparseField();
+
+        $this->assertFalse($attr->isSparseField());
+    }
+
+    public function testSortable(): void
+    {
+        $query = Role::query();
+
+        $attr = ArrayList::make('permissions')->sortable();
+
+        $this->assertTrue($attr->isSortable());
+        $attr->sort($query, 'desc');
+
+        $this->assertSame(
+            [['column' => 'roles.permissions', 'direction' => 'desc']],
+            $query->toBase()->orders
+        );
+    }
+
+    /**
+     * @return array
+     */
+    public function validProvider(): array
+    {
+        return [
+            [[]],
+            [['foo', 'bar']],
+            [null],
+        ];
+    }
+
+    /**
+     * @param $value
+     * @dataProvider validProvider
+     */
+    public function testFill($value): void
+    {
+        $model = new Role();
+        $attr = ArrayList::make('permissions');
+
+        $attr->fill($model, $value);
+        $this->assertSame($value, $model->permissions);
+    }
+
+    /**
+     * @return array
+     */
+    public function invalidProvider(): array
+    {
+        return [
+            [true],
+            [1],
+            [1.0],
+            ['foo'],
+            [''],
+            [new \DateTime()],
+            [['foo' => 'bar', 'baz' => 'bat']],
+        ];
+    }
+
+    /**
+     * @param $value
+     * @dataProvider invalidProvider
+     */
+    public function testFillWithInvalid($value): void
+    {
+        $model = new Role();
+        $attr = ArrayList::make('permissions');
+
+        $this->expectException(\UnexpectedValueException::class);
+        $attr->fill($model, $value);
+    }
+
+    public function testFillRespectsMassAssignment(): void
+    {
+        $model = new Role();
+        $attr = ArrayList::make('accessPermissions');
+
+        $attr->fill($model, ['foo']);
+        $this->assertArrayNotHasKey('access_permissions', $model->getAttributes());
+    }
+
+    public function testUnguarded(): void
+    {
+        $model = new Role();
+        $attr = ArrayList::make('accessPermissions')->unguarded();
+
+        $attr->fill($model, ['foo']);
+        $this->assertSame(['foo'], $model->access_permissions);
+    }
+
+    public function testDeserializeUsing(): void
+    {
+        $model = new Role();
+        $attr = ArrayList::make('permissions')->deserializeUsing(
+            fn($value) => collect($value)
+                ->map(fn($v) => strtoupper($v))
+                ->all()
+        );
+
+        $attr->fill($model, ['foo', 'bar']);
+        $this->assertSame(['FOO', 'BAR'], $model->permissions);
+    }
+
+    public function testFillUsing(): void
+    {
+        $role = new Role();
+        $attr = ArrayList::make('permissions')->fillUsing(function ($model, $column, $value) use ($role) {
+            $this->assertSame($role, $model);
+            $this->assertSame('permissions', $column);
+            $this->assertSame(['foo'], $value);
+            $model->permissions = ['foo', 'bar'];
+        });
+
+        $attr->fill($role, ['foo']);
+        $this->assertSame(['foo', 'bar'], $role->permissions);
+    }
+
+    public function testSorted(): void
+    {
+        $model = new Role();
+        $attr = ArrayList::make('permissions')->sorted();
+
+        $attr->fill($model, ['foo', 'bar']);
+        $this->assertSame(['bar', 'foo'], $model->permissions);
+    }
+
+    public function testReadOnly(): void
+    {
+        $request = $this->createMock(Request::class);
+        $request->expects($this->exactly(2))
+            ->method('wantsJson')
+            ->willReturnOnConsecutiveCalls(true, false);
+
+        $attr = ArrayList::make('permissions')->readOnly(
+            fn($request) => $request->wantsJson()
+        );
+
+        $this->assertTrue($attr->isReadOnly($request));
+        $this->assertFalse($attr->isReadOnly($request));
+    }
+
+    public function testReadOnlyOnCreate(): void
+    {
+        $request = $this->createMock(Request::class);
+        $request->expects($this->exactly(2))
+            ->method('isMethod')
+            ->with('POST')
+            ->willReturnOnConsecutiveCalls(true, false);
+
+        $attr = ArrayList::make('permissions')->readOnlyOnCreate();
+
+        $this->assertTrue($attr->isReadOnly($request));
+        $this->assertFalse($attr->isReadOnly($request));
+    }
+
+    public function testReadOnlyOnUpdate(): void
+    {
+        $request = $this->createMock(Request::class);
+        $request->expects($this->exactly(2))
+            ->method('isMethod')
+            ->with('PATCH')
+            ->willReturnOnConsecutiveCalls(true, false);
+
+        $attr = ArrayList::make('permissions')->readOnlyOnUpdate();
+
+        $this->assertTrue($attr->isReadOnly($request));
+        $this->assertFalse($attr->isReadOnly($request));
+    }
+
+    /**
+     * @return array
+     */
+    public function serializeProvider(): array
+    {
+        return [
+            [null, null],
+            [[], []],
+            [['foo', 'bar'], ['foo', 'bar']],
+            [['foo' => 'bar', 'baz' => 'bat'], ['bar', 'bat']],
+            [[0 => 'foo', 2 => 'bar', 3 => 'bat'], ['foo', 'bar', 'bat']],
+        ];
+    }
+
+    /**
+     * @param $value
+     * @param $expected
+     * @dataProvider serializeProvider
+     */
+    public function testSerialize($value, $expected): void
+    {
+        $model = new Role(['permissions' => $value]);
+
+        $attr = ArrayList::make('permissions');
+
+        $this->assertSame($expected, $attr->serialize($model));
+    }
+
+    public function testSerializeUsing(): void
+    {
+        $model = new Role(['permissions' => ['foo', 'bar']]);
+
+        $attr = ArrayList::make('permissions')->serializeUsing(function ($value) {
+            $this->assertSame(['foo', 'bar'], $value);
+            return [0 => 'baz', 2 => 'bat'];
+        });
+
+        $this->assertSame(['baz', 'bat'], $attr->serialize($model));
+    }
+
+    public function testSerializeSorted(): void
+    {
+        $model = new Role(['permissions' => ['foo', 'bar']]);
+
+        $attr = ArrayList::make('permissions')->sorted();
+
+        $this->assertSame(['bar', 'foo'], $attr->serialize($model));
+    }
+
+    public function testHidden(): void
+    {
+        $request = $this->createMock(Request::class);
+        $request->expects($this->never())->method($this->anything());
+
+        $attr = ArrayList::make('permissions')->hidden();
+
+        $this->assertTrue($attr->isHidden($request));
+    }
+
+    public function testHiddenCallback(): void
+    {
+        $mock = $this->createMock(Request::class);
+        $mock->expects($this->once())->method('isMethod')->with('POST')->willReturn(true);
+
+        $attr = ArrayList::make('permissions')->hidden(
+            fn($request) => $request->isMethod('POST')
+        );
+
+        $this->assertTrue($attr->isHidden($mock));
+    }
+
+}


### PR DESCRIPTION
Updates the Eloquent schema fields so that they support serializing models using the schema. This feature means that the `Resource` class becomes optional - as the Eloquent schema can be used to serialize models if a resource class does not exist.