### PR TITLE
[Feature] Add support for soft deleting models

### DIFF
--- a/src/Fields/Attribute.php
+++ b/src/Fields/Attribute.php
@@ -151,6 +151,18 @@ abstract class Attribute implements AttributeContract, Fillable, Selectable, Sor
     }
 
     /**
+     * Use mass-assignment rules when filling the attribute.
+     *
+     * @return $this
+     */
+    public function guarded(): self
+    {
+        $this->force = false;
+
+        return $this;
+    }
+
+    /**
      * Customise deserialization of the value.
      *
      * @param Closure $deserializer

--- a/src/Fields/DateTime.php
+++ b/src/Fields/DateTime.php
@@ -19,7 +19,8 @@ declare(strict_types=1);
 
 namespace LaravelJsonApi\Eloquent\Fields;
 
-use Carbon\Carbon;
+use Carbon\CarbonInterface;
+use Illuminate\Support\Facades\Date;
 use function config;
 
 class DateTime extends Attribute
@@ -46,7 +47,7 @@ class DateTime extends Attribute
      */
     public static function make(string $fieldName, string $column = null): self
     {
-        return new self($fieldName, $column);
+        return new static($fieldName, $column);
     }
 
     /**
@@ -96,11 +97,22 @@ class DateTime extends Attribute
     {
         $value = parent::deserialize($value);
 
+        return $this->parse($value);
+    }
+
+    /**
+     * Parse a date time value.
+     *
+     * @param CarbonInterface|string|null $value
+     * @return CarbonInterface|null
+     */
+    protected function parse($value): ?CarbonInterface
+    {
         if (is_null($value)) {
             return null;
         }
 
-        $value = Carbon::parse($value);
+        $value = is_string($value) ? Date::parse($value) : Date::instance($value);
 
         if (true === $this->useTz) {
             return $value->setTimezone($this->timezone());

--- a/src/Fields/SoftDelete.php
+++ b/src/Fields/SoftDelete.php
@@ -1,0 +1,90 @@
+<?php
+/*
+ * Copyright 2021 Cloud Creativity Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+declare(strict_types=1);
+
+namespace LaravelJsonApi\Eloquent\Fields;
+
+use Illuminate\Support\Facades\Date;
+use UnexpectedValueException;
+use function boolval;
+use function is_bool;
+use function is_null;
+use function sprintf;
+
+class SoftDelete extends DateTime
+{
+
+    /**
+     * @var bool
+     */
+    private bool $boolean = false;
+
+    /**
+     * SoftDelete constructor.
+     *
+     * @param string $fieldName
+     * @param string|null $column
+     */
+    public function __construct(string $fieldName, string $column = null)
+    {
+        parent::__construct($fieldName, $column);
+        $this->unguarded();
+    }
+
+    /**
+     * @return $this
+     */
+    public function asBoolean(): self
+    {
+        $this->boolean = true;
+
+        return $this;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function serialize(object $model)
+    {
+        if (true === $this->boolean) {
+            return boolval($model->{$this->column()});
+        }
+
+        return parent::serialize($model);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function deserialize($value)
+    {
+        if (true === $this->boolean && (is_bool($value) || is_null($value))) {
+            return $this->parse($value ? Date::now() : null);
+        }
+
+        if (true === $this->boolean) {
+            throw new UnexpectedValueException(sprintf(
+                'Expecting the value of attribute %s to be a boolean.',
+                $this->name()
+            ));
+        }
+
+        return parent::deserialize($value);
+    }
+
+}

--- a/src/Filters/OnlyTrashed.php
+++ b/src/Filters/OnlyTrashed.php
@@ -1,0 +1,43 @@
+<?php
+/*
+ * Copyright 2021 Cloud Creativity Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+declare(strict_types=1);
+
+namespace LaravelJsonApi\Eloquent\Filters;
+
+use LogicException;
+
+class OnlyTrashed extends WithTrashed
+{
+
+    /**
+     * @inheritDoc
+     */
+    public function apply($query, $value)
+    {
+        if (false === $this->deserialize($value)) {
+            return $query;
+        }
+
+        if (is_callable([$query, 'onlyTrashed'])) {
+            return $query->onlyTrashed();
+        }
+
+        throw new LogicException("Filter {$this->key()} expects query builder to have a `withTrashed` method.");
+    }
+
+}

--- a/src/Filters/WhereTrashed.php
+++ b/src/Filters/WhereTrashed.php
@@ -1,0 +1,53 @@
+<?php
+/*
+ * Copyright 2021 Cloud Creativity Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+declare(strict_types=1);
+
+namespace LaravelJsonApi\Eloquent\Filters;
+
+use Illuminate\Database\Eloquent\SoftDeletingScope;
+use LogicException;
+
+class WhereTrashed extends WithTrashed
+{
+
+    /**
+     * @inheritDoc
+     */
+    public function apply($query, $value)
+    {
+        $model = $query->getModel();
+
+        if (!method_exists($model, 'getQualifiedDeletedAtColumn')) {
+            throw new LogicException('Expecting a model that has the soft deletes trait.');
+        }
+
+        $value = $this->deserialize($value);
+        $column = $model->getQualifiedDeletedAtColumn();
+
+        if (true === $value) {
+            return $query
+                ->withoutGlobalScope(SoftDeletingScope::class)
+                ->whereNotNull($column);
+        }
+
+        return $query
+            ->withoutGlobalScope(SoftDeletingScope::class)
+            ->whereNull($column);
+    }
+
+}

--- a/src/Filters/WithTrashed.php
+++ b/src/Filters/WithTrashed.php
@@ -1,0 +1,95 @@
+<?php
+/*
+ * Copyright 2021 Cloud Creativity Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+declare(strict_types=1);
+
+namespace LaravelJsonApi\Eloquent\Filters;
+
+use LaravelJsonApi\Eloquent\Contracts\Filter;
+use LogicException;
+use function filter_var;
+
+class WithTrashed implements Filter
+{
+
+    /**
+     * @var string
+     */
+    private string $name;
+
+    /**
+     * Create a new filter.
+     *
+     * @param string $name
+     * @return static
+     */
+    public static function make(string $name): self
+    {
+        return new static($name);
+    }
+
+    /**
+     * WithTrashed constructor.
+     *
+     * @param string $name
+     */
+    public function __construct(string $name)
+    {
+        $this->name = $name;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function isSingular(): bool
+    {
+        return false;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function apply($query, $value)
+    {
+        $value = $this->deserialize($value);
+
+        if (is_callable([$query, 'withTrashed'])) {
+            return $query->withTrashed($value);
+        }
+
+        throw new LogicException("Filter {$this->key()} expects query builder to have a `withTrashed` method.");
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function key(): string
+    {
+        return $this->name;
+    }
+
+    /**
+     * @param $value
+     * @return bool
+     */
+    protected function deserialize($value): bool
+    {
+        return filter_var($value, FILTER_VALIDATE_BOOL);
+    }
+
+
+}

--- a/src/Hydrators/ModelHydrator.php
+++ b/src/Hydrators/ModelHydrator.php
@@ -42,12 +42,12 @@ class ModelHydrator implements ResourceBuilder
     /**
      * @var Schema
      */
-    private Schema $schema;
+    protected Schema $schema;
 
     /**
      * @var Model
      */
-    private Model $model;
+    protected Model $model;
 
     /**
      * ModelHydrator constructor.
@@ -115,7 +115,7 @@ class ModelHydrator implements ResourceBuilder
      * @param array $validatedData
      * @return void
      */
-    private function fillId(array $validatedData): void
+    protected function fillId(array $validatedData): void
     {
         $field = $this->schema->id();
 
@@ -130,7 +130,7 @@ class ModelHydrator implements ResourceBuilder
      * @param array $validatedData
      * @return void
      */
-    private function fillAttributes(array $validatedData): void
+    protected function fillAttributes(array $validatedData): void
     {
         /** @var Attribute|Fillable $attribute */
         foreach ($this->schema->attributes() as $attribute) {
@@ -156,7 +156,7 @@ class ModelHydrator implements ResourceBuilder
      * @param array $validatedData
      * @return bool
      */
-    private function mustFill(Field $field, array $validatedData): bool
+    protected function mustFill(Field $field, array $validatedData): bool
     {
         if (!$field instanceof Fillable) {
             return false;
@@ -176,7 +176,7 @@ class ModelHydrator implements ResourceBuilder
      * @return array
      *      relationships that have to be filled after the model is saved.
      */
-    private function fillRelationships(array $validatedData): array
+    protected function fillRelationships(array $validatedData): array
     {
         $defer = [];
 
@@ -201,7 +201,7 @@ class ModelHydrator implements ResourceBuilder
      * @param iterable $deferred
      * @param array $validatedData
      */
-    private function fillDeferredRelationships(iterable $deferred, array $validatedData): void
+    protected function fillDeferredRelationships(iterable $deferred, array $validatedData): void
     {
         /** @var Relation|Fillable $field */
         foreach ($deferred as $field) {
@@ -216,7 +216,7 @@ class ModelHydrator implements ResourceBuilder
      *
      * @return void
      */
-    private function persist(): void
+    protected function persist(): void
     {
         if (true !== $this->model->save()) {
             throw new RuntimeException('Failed to save resource.');

--- a/src/Hydrators/SoftDeleteHydrator.php
+++ b/src/Hydrators/SoftDeleteHydrator.php
@@ -1,0 +1,128 @@
+<?php
+/*
+ * Copyright 2021 Cloud Creativity Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+declare(strict_types=1);
+
+namespace LaravelJsonApi\Eloquent\Hydrators;
+
+use LaravelJsonApi\Eloquent\Fields\SoftDelete;
+use LogicException;
+use RuntimeException;
+
+class SoftDeleteHydrator extends ModelHydrator
+{
+
+    /**
+     * @inheritDoc
+     */
+    protected function persist(): void
+    {
+        /**
+         * If the model is being restored, the Laravel restore method executes a
+         * save on the model. So we only need to run the restore method and all
+         * dirty attributes will be saved.
+         */
+        if ($this->willRestore()) {
+            $this->restore();
+            return;
+        }
+
+        /**
+         * To ensure Laravel still executes its soft-delete logic (e.g. firing events)
+         * we need to delete before a save when we are soft-deleting. Although this
+         * may result in two database calls in this scenario, it means we can guarantee
+         * that standard Laravel soft-delete logic is executed.
+         *
+         * When executing the soft delete, Laravel will apply a fresh timestamp to the
+         * model's deleted at column. As the JSON:API client may have provided a different
+         * timestamp, we back up that value first, execute the soft delete, then reapply
+         * the timestamp.
+         *
+         * @see https://github.com/cloudcreativity/laravel-json-api/issues/371
+         */
+        if ($this->willSoftDelete()) {
+            $column = $this->fieldForSoftDelete()->column();
+            // save the original date so we can put it back later on.
+            $deletedAt = $this->model->{$column};
+            // delete the record so that deleting and deleted events get fired.
+            $this->model->delete();
+            // apply the original date back before saving, so that we keep the client's provded date.
+            $this->model->{$column} = $deletedAt;
+        }
+
+        parent::persist();
+    }
+
+    /**
+     * Restore the model.
+     *
+     * As the Eloquent restore method uses `$model->save()`, we also
+     * persist other attributes at this point.
+     */
+    protected function restore(): void
+    {
+        if (true !== $this->model->restore()) {
+            throw new RuntimeException('Failed to save resource.');
+        }
+    }
+
+    /**
+     * Will the hydration operation restore the model?
+     *
+     * @return bool
+     */
+    protected function willRestore(): bool
+    {
+        if (!$this->model->exists) {
+            return false;
+        }
+
+        $column = $this->fieldForSoftDelete()->column();
+
+        return null !== $this->model->getOriginal($column) && null === $this->model->{$column};
+    }
+
+    /**
+     * Will the hydration operation result in the model being soft deleted?
+     *
+     * @return bool
+     */
+    protected function willSoftDelete(): bool
+    {
+        if (!$this->model->exists) {
+            return false;
+        }
+
+        $column = $this->fieldForSoftDelete()->column();
+
+        return null === $this->model->getOriginal($column) && null !== $this->model->{$column};
+    }
+
+    /**
+     * @return SoftDelete
+     */
+    protected function fieldForSoftDelete(): SoftDelete
+    {
+        foreach ($this->schema->attributes() as $attribute) {
+            if ($attribute instanceof SoftDelete) {
+                return $attribute;
+            }
+        }
+
+        throw new LogicException("Expecting schema {$this->schema->type()} to have a soft-delete field.");
+    }
+}

--- a/src/SoftDeleteRepository.php
+++ b/src/SoftDeleteRepository.php
@@ -1,0 +1,76 @@
+<?php
+/*
+ * Copyright 2021 Cloud Creativity Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+declare(strict_types=1);
+
+namespace LaravelJsonApi\Eloquent;
+
+use Illuminate\Database\Eloquent\Model;
+use LaravelJsonApi\Contracts\Store\ResourceBuilder;
+use LaravelJsonApi\Eloquent\Hydrators\SoftDeleteHydrator;
+
+class SoftDeleteRepository extends Repository
+{
+
+    /**
+     * @inheritDoc
+     */
+    public function create(): ResourceBuilder
+    {
+        return new SoftDeleteHydrator(
+            $this->schema,
+            $this->model->newInstance(),
+        );
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function update($modelOrResourceId): ResourceBuilder
+    {
+        return new SoftDeleteHydrator(
+            $this->schema,
+            $this->retrieve($modelOrResourceId),
+        );
+    }
+
+    /**
+     * @param string $resourceId
+     * @return JsonApiBuilder
+     */
+    protected function findQuery(string $resourceId): JsonApiBuilder
+    {
+        return parent::findQuery($resourceId)->withTrashed();
+    }
+
+    /**
+     * @param array $resourceIds
+     * @return JsonApiBuilder
+     */
+    protected function findManyQuery(array $resourceIds): JsonApiBuilder
+    {
+        return parent::findManyQuery($resourceIds)->withTrashed();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function destroy(Model $model): bool
+    {
+        return (bool) $model->forceDelete();
+    }
+}

--- a/src/SoftDeletes.php
+++ b/src/SoftDeletes.php
@@ -1,0 +1,34 @@
+<?php
+/*
+ * Copyright 2021 Cloud Creativity Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+declare(strict_types=1);
+
+namespace LaravelJsonApi\Eloquent;
+
+use LaravelJsonApi\Contracts\Store\Repository as RepositoryContract;
+
+trait SoftDeletes
+{
+
+    /**
+     * @return RepositoryContract
+     */
+    public function repository(): RepositoryContract
+    {
+        return new SoftDeleteRepository($this);
+    }
+}

--- a/tests/app/Models/Country.php
+++ b/tests/app/Models/Country.php
@@ -22,11 +22,13 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasManyThrough;
+use Illuminate\Database\Eloquent\SoftDeletes;
 
 class Country extends Model
 {
 
     use HasFactory;
+    use SoftDeletes;
 
     /**
      * @var string[]

--- a/tests/app/Models/Post.php
+++ b/tests/app/Models/Post.php
@@ -25,11 +25,13 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Illuminate\Database\Eloquent\Relations\MorphOne;
 use Illuminate\Database\Eloquent\Relations\MorphToMany;
+use Illuminate\Database\Eloquent\SoftDeletes;
 
 class Post extends Model
 {
 
     use HasFactory;
+    use SoftDeletes;
 
     /**
      * @var string[]

--- a/tests/app/Schemas/PostSchema.php
+++ b/tests/app/Schemas/PostSchema.php
@@ -29,8 +29,11 @@ use LaravelJsonApi\Eloquent\Fields\Relations\HasMany;
 use LaravelJsonApi\Eloquent\Fields\Relations\HasOne;
 use LaravelJsonApi\Eloquent\Fields\SoftDelete;
 use LaravelJsonApi\Eloquent\Fields\Str;
+use LaravelJsonApi\Eloquent\Filters\OnlyTrashed;
 use LaravelJsonApi\Eloquent\Filters\Where;
 use LaravelJsonApi\Eloquent\Filters\WhereIn;
+use LaravelJsonApi\Eloquent\Filters\WhereTrashed;
+use LaravelJsonApi\Eloquent\Filters\WithTrashed;
 use LaravelJsonApi\Eloquent\Pagination\PagePagination;
 use LaravelJsonApi\Eloquent\Schema;
 use LaravelJsonApi\Eloquent\SoftDeletes;
@@ -79,8 +82,11 @@ class PostSchema extends Schema
     {
         return [
             WhereIn::make('id', $this->idColumn()),
+            OnlyTrashed::make('onlyTrashed'),
             Where::make('slug')->singular(),
             WhereIn::make('slugs')->delimiter(','),
+            WhereTrashed::make('trashed'),
+            WithTrashed::make('withTrashed'),
         ];
     }
 

--- a/tests/app/Schemas/PostSchema.php
+++ b/tests/app/Schemas/PostSchema.php
@@ -27,14 +27,18 @@ use LaravelJsonApi\Eloquent\Fields\Relations\BelongsTo;
 use LaravelJsonApi\Eloquent\Fields\Relations\BelongsToMany;
 use LaravelJsonApi\Eloquent\Fields\Relations\HasMany;
 use LaravelJsonApi\Eloquent\Fields\Relations\HasOne;
+use LaravelJsonApi\Eloquent\Fields\SoftDelete;
 use LaravelJsonApi\Eloquent\Fields\Str;
 use LaravelJsonApi\Eloquent\Filters\Where;
 use LaravelJsonApi\Eloquent\Filters\WhereIn;
 use LaravelJsonApi\Eloquent\Pagination\PagePagination;
 use LaravelJsonApi\Eloquent\Schema;
+use LaravelJsonApi\Eloquent\SoftDeletes;
 
 class PostSchema extends Schema
 {
+
+    use SoftDeletes;
 
     /**
      * The model the schema corresponds to.
@@ -59,6 +63,7 @@ class PostSchema extends Schema
             DateTime::make('createdAt')->sortable()->readOnly(),
             HasMany::make('comments'),
             Str::make('content'),
+            SoftDelete::make('deletedAt')->sortable(),
             HasOne::make('image'),
             Str::make('slug')->sortable(),
             BelongsToMany::make('tags')->fields(new ApprovedPivot()),

--- a/tests/database/migrations/2020_11_09_0935_create_user_tables.php
+++ b/tests/database/migrations/2020_11_09_0935_create_user_tables.php
@@ -34,6 +34,7 @@ class CreateUserTables extends Migration
         Schema::create('countries', function (Blueprint $table) {
             $table->id();
             $table->timestamps();
+            $table->softDeletes();
             $table->string('name');
         });
 

--- a/tests/database/migrations/2020_11_10_0953_create_post_and_video_tables.php
+++ b/tests/database/migrations/2020_11_10_0953_create_post_and_video_tables.php
@@ -34,6 +34,7 @@ class CreatePostAndVideoTables extends Migration
         Schema::create('posts', function (Blueprint $table) {
             $table->id();
             $table->timestamps();
+            $table->softDeletes();
             $table->unsignedBigInteger('user_id');
             $table->string('title');
             $table->string('slug')->unique();

--- a/tests/lib/Acceptance/SoftDeleteHiddenTest.php
+++ b/tests/lib/Acceptance/SoftDeleteHiddenTest.php
@@ -1,0 +1,112 @@
+<?php
+/*
+ * Copyright 2021 Cloud Creativity Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+declare(strict_types=1);
+
+namespace LaravelJsonApi\Eloquent\Tests\Acceptance;
+
+use App\Models\Country;
+use App\Schemas\CountrySchema;
+use Carbon\Carbon;
+
+class SoftDeleteHiddenTest extends TestCase
+{
+
+    /**
+     * @var CountrySchema
+     */
+    private CountrySchema $schema;
+
+    /**
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        /**
+         * The country model uses the Eloquent soft-deletes trait, but it does not
+         * implement the JSON:API soft-deletes trait on its schema. This means
+         * soft-deleted countries should not exist in the API.
+         */
+        $this->schema = $this->app->make(CountrySchema::class);
+    }
+
+    public function testFindAndExistsWithTrashed(): void
+    {
+        $country = Country::factory()->create(['deleted_at' => Carbon::now()]);
+
+        $this->assertNull(
+            $this->schema->repository()->find((string) $country->getRouteKey())
+        );
+
+        $this->assertFalse(
+            $this->schema->repository()->exists((string) $country->getRouteKey())
+        );
+    }
+
+    public function testFindAndExistsWithNotTrashed(): void
+    {
+        $country = Country::factory()->create(['deleted_at' => null]);
+
+        $actual = $this->schema->repository()->find((string) $country->getRouteKey());
+
+        $this->assertTrue($country->is($actual));
+
+        $this->assertTrue(
+            $this->schema->repository()->exists((string) $country->getRouteKey())
+        );
+    }
+
+    public function testFindMany(): void
+    {
+        $countries = Country::factory()->count(5)->sequence(
+            ['deleted_at' => null],
+            ['deleted_at' => Carbon::now()],
+        )->create();
+
+        $ids = $countries
+            ->map(fn(Country $country) => (string) $country->getRouteKey())
+            ->all();
+
+        $expected = $countries
+            ->filter(fn(Country $country) => is_null($country->deleted_at))
+            ->sortBy('id')
+            ->pluck('id')
+            ->all();
+
+        $actual = $this->schema
+            ->repository()
+            ->findMany($ids);
+
+        $this->assertCount(count($expected), $actual);
+
+        $this->assertSame(
+            $expected,
+            collect($actual)->sortBy('id')->pluck('id')->all()
+        );
+    }
+
+    public function testDelete(): void
+    {
+        $country = Country::factory()->create(['deleted_at' => null]);
+
+        $this->schema->repository()->delete($country);
+
+        $this->assertSoftDeleted($country);
+    }
+}

--- a/tests/lib/Acceptance/SoftDeleteTest.php
+++ b/tests/lib/Acceptance/SoftDeleteTest.php
@@ -1,0 +1,413 @@
+<?php
+/*
+ * Copyright 2021 Cloud Creativity Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+declare(strict_types=1);
+
+namespace LaravelJsonApi\Eloquent\Tests\Acceptance;
+
+use App\Models\Post;
+use App\Models\User;
+use App\Schemas\PostSchema;
+use Carbon\Carbon;
+
+class SoftDeleteTest extends TestCase
+{
+
+    /**
+     * @var PostSchema
+     */
+    private PostSchema $schema;
+
+    /**
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->schema = $this->app->make(PostSchema::class);
+
+        Post::creating(function (Post $post) {
+            $post->user()->associate(User::factory()->create());
+        });
+    }
+
+    /**
+     * @return array
+     */
+    public function trashedProvider(): array
+    {
+        return [
+            'trashed' => [new Carbon()],
+            'not_trashed' => [null],
+        ];
+    }
+
+    /**
+     * @param $deletedAt
+     * @dataProvider trashedProvider
+     */
+    public function testFind($deletedAt): void
+    {
+        $post = Post::factory()->create(['deleted_at' => $deletedAt]);
+
+        $actual = $this->schema
+            ->repository()
+            ->find((string) $post->getRouteKey());
+
+        $this->assertTrue($post->is($actual));
+    }
+
+    /**
+     * @param $deletedAt
+     * @dataProvider trashedProvider
+     */
+    public function testExists($deletedAt): void
+    {
+        $post = Post::factory()->create(['deleted_at' => $deletedAt]);
+
+        $actual = $this->schema
+            ->repository()
+            ->exists((string) $post->getRouteKey());
+
+        $this->assertTrue($actual);
+    }
+
+    public function testFindMany(): void
+    {
+        $posts = Post::factory()->count(3)->sequence(
+            ['deleted_at' => null],
+            ['deleted_at' => new Carbon()],
+        )->create();
+
+        Post::factory()->create(['deleted_at' => null]);
+        Post::factory()->create(['deleted_at' => new Carbon()]);
+
+        $ids = $posts
+            ->map(fn(Post $post) => (string) $post->getRouteKey())
+            ->all();
+
+        $actual = $this->schema
+            ->repository()
+            ->findMany($ids);
+
+        $this->assertCount(count($posts), $actual);
+    }
+
+    /**
+     * @param $deletedAt
+     * @dataProvider trashedProvider
+     */
+    public function testItForceDeletesModel($deletedAt): void
+    {
+        $forceDeleted = false;
+
+        Post::forceDeleted(function () use (&$forceDeleted) {
+            $forceDeleted = true;
+        });
+
+        $post = Post::factory()->create(['deleted_at' => $deletedAt]);
+
+        $this->schema->repository()->delete((string) $post->getRouteKey());
+
+        $this->assertDeleted($post);
+        $this->assertTrue($forceDeleted);
+    }
+
+    public function testItDoesNotRestoreOnCreate(): void
+    {
+        $post = Post::factory()->make();
+
+        $data = [
+            'content' => $post->content,
+            'deletedAt' => null,
+            'slug' => $post->slug,
+            'title' => $post->title,
+        ];
+
+        $this->willNotRestore()
+            ->willNotSoftDelete()
+            ->willNotForceDelete();
+
+        $actual = $this->schema
+            ->repository()
+            ->create()
+            ->store($data);
+
+        $this->assertFalse($actual->trashed());
+
+        $this->assertDatabaseHas('posts', [
+            $post->getKeyName() => $actual->getKey(),
+            'content' => $post->content,
+            'deleted_at' => null,
+            'slug' => $post->slug,
+            'title' => $post->title,
+        ]);
+    }
+
+    /**
+     * We cannot soft delete on create because the model `delete()` method
+     * does not run if the model does not exist. This means Laravel does not
+     * allow us to soft delete a model we are creating.
+     *
+     * If the client provides a value for the soft delete column when creating,
+     * we expect the model to be created in a trashed state, but without any
+     * deleting events firing (as Laravel does not allow that).
+     *
+     * If the developer wants to prevent a client from soft-deleting the
+     * model on create, they should use validation rules to reject the
+     * request: or omit the deleted column value by not validating it on a
+     * create request.
+     */
+    public function testItDoesNotSoftDeleteOnCreate(): void
+    {
+        $expected = Carbon::now()->subHour()->startOfSecond();
+
+        $post = Post::factory()->make();
+
+        $data = [
+            'content' => $post->content,
+            'deletedAt' => $expected->toJSON(),
+            'slug' => $post->slug,
+            'title' => $post->title,
+        ];
+
+        $this->willNotRestore()
+            ->willNotSoftDelete()
+            ->willNotForceDelete();
+
+        $actual = $this->schema
+            ->repository()
+            ->create()
+            ->store($data);
+
+        $this->assertTrue($actual->trashed());
+
+        $this->assertDatabaseHas('posts', [
+            $post->getKeyName() => $actual->getKey(),
+            'content' => $post->content,
+            'deleted_at' => $expected->toDateTimeString(),
+            'slug' => $post->slug,
+            'title' => $post->title,
+        ]);
+    }
+
+    public function testItSoftDeletesOnUpdate(): void
+    {
+        $deleted = false;
+
+        Post::deleted(function () use (&$deleted) {
+            $deleted = true;
+        });
+
+        $expected = Carbon::yesterday()->startOfSecond();
+        $post = Post::factory()->create(['deleted_at' => null]);
+
+        $data = [
+            'deletedAt' => $expected->toJSON(),
+        ];
+
+        $this->willNotRestore()->willNotForceDelete();
+
+        $actual = $this->schema
+            ->repository()
+            ->update($post)
+            ->store($data);
+
+        $this->assertTrue($actual->trashed());
+        $this->assertTrue($deleted);
+        $this->assertSoftDeleted($post);
+    }
+
+    public function testItSoftDeletesAndUpdatesOtherFields(): void
+    {
+        $deleted = false;
+
+        Post::deleted(function () use (&$deleted) {
+            $deleted = true;
+        });
+
+        $expected = Carbon::yesterday()->startOfSecond();
+        $post = Post::factory()->create(['deleted_at' => null]);
+
+        $data = [
+            'deletedAt' => $expected->toJSON(),
+            'title' => 'Hello World!',
+        ];
+
+        $this->willNotRestore()->willNotForceDelete();
+
+        $actual = $this->schema
+            ->repository()
+            ->update($post)
+            ->store($data);
+
+        $this->assertTrue($actual->trashed());
+        $this->assertTrue($deleted);
+
+        $this->assertDatabaseHas('posts', array_merge($post->getOriginal(), [
+            'deleted_at' => $expected->toDateTimeString(),
+            'title' => $data['title'],
+        ]));
+    }
+
+    public function testItDoesNotSoftDeleteOnUpdate(): void
+    {
+        $post = Post::factory()->create(['deleted_at' => null]);
+
+        $data = ['deletedAt' => null, 'title' => 'Hello World!'];
+
+        $this->willNotSoftDelete()
+            ->willNotForceDelete()
+            ->willNotRestore();
+
+        $actual = $this->schema
+            ->repository()
+            ->update($post)
+            ->store($data);
+
+        $this->assertFalse($actual->trashed());
+
+        $this->assertDatabaseHas('posts', array_merge($post->getOriginal(), [
+            'deleted_at' => null,
+            'title' => $data['title'],
+        ]));
+    }
+
+    public function testItRestores(): void
+    {
+        $restored = false;
+
+        Post::restored(function () use (&$restored) {
+            $restored = true;
+        });
+
+        $post = Post::factory()->create(['deleted_at' => Carbon::now()]);
+
+        $data = [
+            'deletedAt' => null,
+        ];
+
+        $this->willNotSoftDelete()->willNotForceDelete();
+
+        $actual = $this->schema
+            ->repository()
+            ->update($post)
+            ->store($data);
+
+        $this->assertFalse($actual->trashed());
+        $this->assertTrue($restored);
+        $this->assertDatabaseHas('posts', array_merge($post->getOriginal(), [
+            'deleted_at' => null,
+        ]));
+    }
+
+    public function testItRestoresAndUpdatesOtherFields(): void
+    {
+        $restored = false;
+
+        Post::restored(function () use (&$restored) {
+            $restored = true;
+        });
+
+        $post = Post::factory()->create(['deleted_at' => Carbon::now()]);
+
+        $data = [
+            'deletedAt' => null,
+            'title' => 'Hello World!',
+        ];
+
+        $this->willNotSoftDelete()->willNotForceDelete();
+
+        $actual = $this->schema
+            ->repository()
+            ->update($post)
+            ->store($data);
+
+        $this->assertFalse($actual->trashed());
+        $this->assertTrue($restored);
+
+        $this->assertDatabaseHas('posts', array_merge($post->getOriginal(), [
+            'deleted_at' => null,
+            'title' => $data['title'],
+        ]));
+    }
+
+    /**
+     * If the model is already trashed, the soft delete events should not be triggered
+     * even if the client is changing the date on which it was trashed.
+     */
+    public function testItDoesNotRestoreOnUpdate(): void
+    {
+        $expected = Carbon::now()->subWeek()->startOfSecond();
+        $post = Post::factory()->create(['deleted_at' => Carbon::now()]);
+
+        $data = ['deletedAt' => $expected->toJSON(), 'title' => 'Hello World!'];
+
+        $this->willNotSoftDelete()
+            ->willNotForceDelete()
+            ->willNotRestore();
+
+        $actual = $this->schema
+            ->repository()
+            ->update($post)
+            ->store($data);
+
+        $this->assertTrue($actual->trashed());
+
+        $this->assertDatabaseHas('posts', array_merge($post->getOriginal(), [
+            'deleted_at' => $expected->toDateTimeString(),
+            'title' => $data['title'],
+        ]));
+    }
+
+    /**
+     * @return $this
+     */
+    private function willNotSoftDelete(): self
+    {
+        Post::deleted(function () {
+            throw new \LogicException('Not expecting a restore event.');
+        });
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
+    private function willNotRestore(): self
+    {
+        Post::restored(function () {
+            throw new \LogicException('Not expecting a restore event.');
+        });
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
+    private function willNotForceDelete(): self
+    {
+        Post::forceDeleted(function () {
+            throw new \LogicException('Not expecting a restore event.');
+        });
+
+        return $this;
+    }
+}

--- a/tests/lib/Acceptance/SoftDeleteTest.php
+++ b/tests/lib/Acceptance/SoftDeleteTest.php
@@ -433,6 +433,126 @@ class SoftDeleteTest extends TestCase
         ]));
     }
 
+    public function testWithTrashedIsTrue(): void
+    {
+        $posts = Post::factory()->count(5)->sequence(
+            ['deleted_at' => null],
+            ['deleted_at' => Carbon::now()],
+        )->create();
+
+        $actual = $this->schema
+            ->repository()
+            ->queryAll()
+            ->filter(['withTrashed' => 'true'])
+            ->get();
+
+        $this->assertPosts($posts, $actual);
+    }
+
+    public function testWithTrashedIsFalse(): void
+    {
+        $posts = Post::factory()->count(5)->sequence(
+            ['deleted_at' => null],
+            ['deleted_at' => Carbon::now()],
+        )->create();
+
+        $expected = $posts->reject(fn(Post $post) => $post->trashed());
+
+        $actual = $this->schema
+            ->repository()
+            ->queryAll()
+            ->filter(['withTrashed' => 'false'])
+            ->get();
+
+        $this->assertPosts($expected, $actual);
+    }
+
+    public function testOnlyTrashedIsTrue(): void
+    {
+        $posts = Post::factory()->count(5)->sequence(
+            ['deleted_at' => null],
+            ['deleted_at' => Carbon::now()],
+        )->create();
+
+        $expected = $posts->filter(fn(Post $post) => $post->trashed());
+
+        $actual = $this->schema
+            ->repository()
+            ->queryAll()
+            ->filter(['onlyTrashed' => 'true'])
+            ->get();
+
+        $this->assertPosts($expected, $actual);
+    }
+
+    public function testOnlyTrashedIsFalse(): void
+    {
+        $posts = Post::factory()->count(5)->sequence(
+            ['deleted_at' => null],
+            ['deleted_at' => Carbon::now()],
+        )->create();
+
+        $expected = $posts->reject(fn(Post $post) => $post->trashed());
+
+        $actual = $this->schema
+            ->repository()
+            ->queryAll()
+            ->filter(['onlyTrashed' => 'false'])
+            ->get();
+
+        $this->assertPosts($expected, $actual);
+    }
+
+    public function testWhereTrashedIsTrue(): void
+    {
+        $posts = Post::factory()->count(5)->sequence(
+            ['deleted_at' => null],
+            ['deleted_at' => Carbon::now()],
+        )->create();
+
+        $expected = $posts->filter(fn(Post $post) => $post->trashed());
+
+        $actual = $this->schema
+            ->repository()
+            ->queryAll()
+            ->filter(['trashed' => 'true'])
+            ->get();
+
+        $this->assertPosts($expected, $actual);
+    }
+
+    public function testWhereTrashedIsFalse(): void
+    {
+        $posts = Post::factory()->count(5)->sequence(
+            ['deleted_at' => null],
+            ['deleted_at' => Carbon::now()],
+        )->create();
+
+        $expected = $posts->reject(fn(Post $post) => $post->trashed());
+
+        $actual = $this->schema
+            ->repository()
+            ->queryAll()
+            ->filter(['trashed' => 'false'])
+            ->get();
+
+        $this->assertPosts($expected, $actual);
+    }
+
+    /**
+     * @param $expected
+     * @param $actual
+     */
+    private function assertPosts($expected, $actual): void
+    {
+        $this->assertCount(count($expected), $actual);
+
+        $this->assertSame(
+            collect($expected)->sortBy('id')->pluck('id')->all(),
+            collect($actual)->sortBy('id')->pluck('id')->all()
+        );
+    }
+
     /**
      * @return $this
      */


### PR DESCRIPTION
Updates the package so that it now supports soft deleting. To do this, there is now a `SoftDeleteRepository` and `SoftDeleteHydrator`, that extend the existing classes and override the methods required to handle soft delete models.

If a model is soft-deletable, but the schema is not modified, then the model will be soft-deleted on a `DELETE` request, and will then not appear in the API.

If the soft delete functionality should be exposed to the client, then the `LaravelJsonApi\Eloquent\SoftDeletes` trait should be added to the schema, and an instance of `LaravelJsonApi\Eloquent\Fields\SoftDelete` should be added to the schema's fields. Once this is done, a client can soft-delete or restore a resource using a `PATCH` request, with the standard Eloquent delete/restore events fired as a result. A `DELETE` request will force delete the resource.

The PR also adds three filters. `OnlyTrashed` and `WithTrashed` use the `onlyTrashed()` and `withTrashed()` scopes that Eloquent adds for soft deletable models. The `WhereTrashed` effectively allows resources to be filtered by whether they are trashed or not (which is a slightly different behaviour to the Eloquent `withTrashed()` scope).

Implements https://github.com/laravel-json-api/laravel/issues/43