### PR TITLE
[Feature] Add polymorphic to-many relation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ All notable changes to this project will be documented in this file. This projec
 - The package now supports multi-resource models. This feature allows a model to be represented as more than one JSON:
   API resource class and works by having proxy classes for each additional representation of a model. Refer to
   documentation for examples and details of how to implement multi-resource models.
+- [#7](https://github.com/laravel-json-api/eloquent/pull/7) Added a new `MorphToMany` JSON:API relation field. This
+  wraps several sub-relation fields and presents them as a single polymorphic relationship. The relationship value works
+  both as the `data` member of the relationship object and as a relationship end-point. The relationship is modifiable
+  when every sub-relation is writeable (implements the `FillableToMany` relation) and each resource type that can be in
+  the relationship maps to a single sub-relation. Include paths also work, with the include paths only being applied to
+  the sub-relations for which they are valid.
 
 ### Changed
 
@@ -24,6 +30,12 @@ All notable changes to this project will be documented in this file. This projec
 - **BREAKING** Repositories are now injected with a driver which defines the database interactions for the repository.
   This allows database interactions to be modified, without having to rewrite the repository class - and is used as to
   implement the soft-deletes feature.
+- **BREAKING** The `sync`, `attach` and `detach` methods on the `FillableToMany` interface now type-hint `iterable` as
+  their return type. Previously they type-hinted the Eloquent collection class.
+- **BREAKING** The eager load implementation has been modified to support the new polymorphic to-many relation.
+  Generally this should not cause any breaking changes, because the eager loading classes were effectively used
+  internally to handle eager loading. Changes include removing the `skipMissingFields` methods (that existed in multiple
+  locations) and rewriting the `EagerLoadPath` class.
 
 ### Removed
 

--- a/src/Contracts/FillableToMany.php
+++ b/src/Contracts/FillableToMany.php
@@ -21,6 +21,7 @@ namespace LaravelJsonApi\Eloquent\Contracts;
 
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 use Illuminate\Database\Eloquent\Model;
+use LaravelJsonApi\Eloquent\Polymorphism\MorphMany;
 
 interface FillableToMany extends Fillable
 {
@@ -30,25 +31,25 @@ interface FillableToMany extends Fillable
      *
      * @param Model $model
      * @param array $identifiers
-     * @return EloquentCollection
+     * @return EloquentCollection|MorphMany
      */
-    public function sync(Model $model, array $identifiers): EloquentCollection;
+    public function sync(Model $model, array $identifiers): iterable;
 
     /**
      * Add the specified members to the relationship unless they are already present.
      *
      * @param Model $model
      * @param array $identifiers
-     * @return EloquentCollection
+     * @return EloquentCollection|MorphMany
      */
-    public function attach(Model $model, array $identifiers): EloquentCollection;
+    public function attach(Model $model, array $identifiers): iterable;
 
     /**
      * Remove the specified members from the relationship.
      *
      * @param Model $model
      * @param array $identifiers
-     * @return EloquentCollection
+     * @return EloquentCollection|MorphMany
      */
-    public function detach(Model $model, array $identifiers): EloquentCollection;
+    public function detach(Model $model, array $identifiers): iterable;
 }

--- a/src/EagerLoading/EagerLoadPathList.php
+++ b/src/EagerLoading/EagerLoadPathList.php
@@ -1,0 +1,160 @@
+<?php
+/*
+ * Copyright 2021 Cloud Creativity Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+declare(strict_types=1);
+
+namespace LaravelJsonApi\Eloquent\EagerLoading;
+
+use IteratorAggregate;
+use LaravelJsonApi\Core\Query\RelationshipPath;
+use LaravelJsonApi\Eloquent\Fields\Relations\Relation;
+use LaravelJsonApi\Eloquent\Schema;
+use LogicException;
+
+class EagerLoadPathList implements IteratorAggregate
+{
+
+    /**
+     * @var Schema
+     */
+    private Schema $schema;
+
+    /**
+     * @var RelationshipPath
+     */
+    private RelationshipPath $path;
+
+    /**
+     * @var array|null
+     */
+    private ?array $paths = null;
+
+    /**
+     * EagerLoadPathList constructor.
+     *
+     * @param Schema $schema
+     * @param RelationshipPath $path
+     */
+    public function __construct(Schema $schema, RelationshipPath $path)
+    {
+        $this->schema = $schema;
+        $this->path = $path;
+    }
+
+    /**
+     * Get the default eager load paths.
+     *
+     * @return iterable
+     */
+    public function defaults(): iterable
+    {
+        foreach ($this->cachedPaths() as $path) {
+            foreach ($path->defaults() as $default) {
+                yield $default;
+            }
+        }
+    }
+
+    /**
+     * Get the eager load paths for the relationship path.
+     *
+     * @return array
+     */
+    public function paths(): iterable
+    {
+        foreach ($this->cachedPaths() as $path) {
+            yield $path->toString();
+        }
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getIterator()
+    {
+        foreach ($this->defaults() as $default) {
+            yield $default;
+        }
+
+        foreach ($this->paths() as $path) {
+            yield $path;
+        }
+    }
+
+    /**
+     * Get the first relationship.
+     *
+     * @return Relation
+     */
+    private function relation(): Relation
+    {
+        $relation = $this->schema->relationship(
+            $this->path->first()
+        );
+
+        if ($relation instanceof Relation) {
+            return $relation;
+        }
+
+        throw new LogicException('Expecting an Eloquent relationship.');
+    }
+
+    /**
+     * @return EagerLoadPath[]
+     */
+    private function cachedPaths(): array
+    {
+        if (is_array($this->paths)) {
+            return $this->paths;
+        }
+
+        return $this->paths = $this->compute();
+    }
+
+    /**
+     * Calculate the eager load paths for the provided relationship path.
+     *
+     * Due to polymorphic to-many relationships, one JSON:API include path
+     * can be mapped to one or many Eloquent eager load paths.
+     *
+     * @return array
+     */
+    private function compute(): array
+    {
+        $paths = EagerLoadPath::make($this->relation());
+        $terminated = [];
+
+        if ($path = $this->path->skip(1)) {
+            foreach ($path as $idx => $name) {
+                $retain = [];
+                foreach ($paths as $path) {
+                    if (is_array($next = $path->next($name))) {
+                        $retain = array_merge($retain, $next);
+                        continue;
+                    }
+
+                    $terminated[] = $path;
+                }
+
+                $paths = $retain;
+            }
+        }
+
+        return array_merge($paths, $terminated);
+    }
+
+}

--- a/src/EagerLoading/EagerLoader.php
+++ b/src/EagerLoading/EagerLoader.php
@@ -61,11 +61,6 @@ class EagerLoader
     private $query;
 
     /**
-     * @var bool
-     */
-    private bool $skipMissingFields = false;
-
-    /**
      * EagerLoader constructor.
      *
      * @param Container $schemas
@@ -75,16 +70,6 @@ class EagerLoader
     {
         $this->schemas = $schemas;
         $this->schema = $schema;
-    }
-
-    /**
-     * @return $this
-     */
-    public function skipMissingFields(): self
-    {
-        $this->skipMissingFields = true;
-
-        return $this;
     }
 
     /**
@@ -189,7 +174,6 @@ class EagerLoader
     public function toRelations($includePaths): array
     {
         $paths = new EagerLoadIterator($this->schemas, $this->schema, $includePaths);
-        $paths->skipMissingFields($this->skipMissingFields);
 
         return $paths->all();
     }
@@ -237,10 +221,9 @@ class EagerLoader
             return true;
         }
 
-        foreach ($relation->inverseTypes() as $type) {
-            $schema = $this->schemas->schemaFor($type);
-
-            if ($schema instanceof Schema && !empty($schema->with())) {
+        /** @var Schema $schema */
+        foreach ($relation->allSchemas() as $schema) {
+            if (!empty($schema->with())) {
                 return true;
             }
         }

--- a/src/Fields/Relations/BelongsToMany.php
+++ b/src/Fields/Relations/BelongsToMany.php
@@ -22,6 +22,7 @@ namespace LaravelJsonApi\Eloquent\Fields\Relations;
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany as EloquentBelongsToMany;
+use Illuminate\Support\Collection;
 use InvalidArgumentException;
 use LaravelJsonApi\Eloquent\Contracts\FillableToMany;
 use LaravelJsonApi\Eloquent\Fields\Concerns\ReadOnly;
@@ -101,7 +102,7 @@ class BelongsToMany extends ToMany implements FillableToMany
     /**
      * @inheritDoc
      */
-    public function sync(Model $model, array $identifiers): EloquentCollection
+    public function sync(Model $model, array $identifiers): iterable
     {
         $related = $this->findMany($identifiers);
         $relation = $this->getRelation($model);
@@ -120,7 +121,7 @@ class BelongsToMany extends ToMany implements FillableToMany
     /**
      * @inheritDoc
      */
-    public function attach(Model $model, array $identifiers): EloquentCollection
+    public function attach(Model $model, array $identifiers): iterable
     {
         $related = $this->findMany($identifiers);
         $relation = $this->getRelation($model);
@@ -148,7 +149,7 @@ class BelongsToMany extends ToMany implements FillableToMany
     /**
      * @inheritDoc
      */
-    public function detach(Model $model, array $identifiers): EloquentCollection
+    public function detach(Model $model, array $identifiers): iterable
     {
         $related = $this->findMany($identifiers);
 

--- a/src/Fields/Relations/HasMany.php
+++ b/src/Fields/Relations/HasMany.php
@@ -62,7 +62,7 @@ class HasMany extends ToMany implements FillableToMany
     /**
      * @inheritDoc
      */
-    public function sync(Model $model, array $identifiers): EloquentCollection
+    public function sync(Model $model, array $identifiers): iterable
     {
         $models = $this->findMany($identifiers);
 
@@ -75,7 +75,7 @@ class HasMany extends ToMany implements FillableToMany
     /**
      * @inheritDoc
      */
-    public function attach(Model $model, array $identifiers): EloquentCollection
+    public function attach(Model $model, array $identifiers): iterable
     {
         $models = $this->findMany($identifiers);
 
@@ -88,7 +88,7 @@ class HasMany extends ToMany implements FillableToMany
     /**
      * @inheritDoc
      */
-    public function detach(Model $model, array $identifiers): EloquentCollection
+    public function detach(Model $model, array $identifiers): iterable
     {
         $models = $this->findMany($identifiers);
 

--- a/src/Fields/Relations/MorphTo.php
+++ b/src/Fields/Relations/MorphTo.php
@@ -105,6 +105,26 @@ class MorphTo extends BelongsTo implements PolymorphicRelation
     }
 
     /**
+     * @return Generator
+     */
+    public function allSchemas(): Generator
+    {
+        foreach ($this->inverseTypes() as $type) {
+            $schema = $this->schemas()->schemaFor($type);
+
+            if ($schema instanceof Schema) {
+                yield $type => $schema;
+                continue;
+            }
+
+            throw new LogicException(sprintf(
+                'Expecting schema for resource type %s to be an Eloquent schema.',
+                $type
+            ));
+        }
+    }
+
+    /**
      * @param string $type
      * @return void
      */
@@ -118,26 +138,6 @@ class MorphTo extends BelongsTo implements PolymorphicRelation
                 $type,
                 $this->name(),
                 implode(', ', $expected),
-            ));
-        }
-    }
-
-    /**
-     * @return Generator
-     */
-    private function allSchemas(): Generator
-    {
-        foreach ($this->inverseTypes() as $type) {
-            $schema = $this->schemas()->schemaFor($type);
-
-            if ($schema instanceof Schema) {
-                yield $type => $schema;
-                continue;
-            }
-
-            throw new LogicException(sprintf(
-                'Expecting schema for resource type %s to be an Eloquent schema.',
-                $type
             ));
         }
     }

--- a/src/Fields/Relations/MorphToMany.php
+++ b/src/Fields/Relations/MorphToMany.php
@@ -1,0 +1,105 @@
+<?php
+/*
+ * Copyright 2021 Cloud Creativity Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+declare(strict_types=1);
+
+namespace LaravelJsonApi\Eloquent\Fields\Relations;
+
+use InvalidArgumentException;
+use LaravelJsonApi\Contracts\Schema\Container;
+use LaravelJsonApi\Contracts\Schema\PolymorphicRelation;
+use IteratorAggregate;
+use UnexpectedValueException;
+
+class MorphToMany extends ToMany implements PolymorphicRelation, IteratorAggregate
+{
+
+    /**
+     * @var array
+     */
+    private array $relations;
+
+    /**
+     * @param string $fieldName
+     * @param array $relations
+     * @return static
+     */
+    public static function make(string $fieldName, array $relations): self
+    {
+        return new self($fieldName, $relations);
+    }
+
+    /**
+     * MorphMany constructor.
+     *
+     * @param string $fieldName
+     * @param array $relations
+     */
+    public function __construct(string $fieldName, array $relations)
+    {
+        if (2 > count($relations)) {
+            throw new InvalidArgumentException('Expecting morph-many to have more than one relation.');
+        }
+
+        parent::__construct($fieldName);
+        $this->relations = $relations;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function inverseTypes(): array
+    {
+        return collect($this->relations)
+            ->map(fn(ToMany $relation) => $relation->inverse())
+            ->all();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function withSchemas(Container $container): void
+    {
+        foreach ($this as $relation) {
+            $relation->withSchemas($container);
+        }
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getIterator(): iterable
+    {
+        foreach ($this->relations as $relation) {
+            if ($relation instanceof self) {
+                throw new UnexpectedValueException(
+                    'Cannot have a JSON:API morph-to-many relation within a morph-to-many relation.'
+                );
+            }
+
+            if ($relation instanceof Relation) {
+                yield $relation;
+                continue;
+            }
+
+            throw new UnexpectedValueException(
+                'JSON:API morph-to-many relation expects to receive JSON:API relation objects.'
+            );
+        }
+    }
+
+}

--- a/src/Fields/Relations/MorphToMany.php
+++ b/src/Fields/Relations/MorphToMany.php
@@ -19,6 +19,9 @@ declare(strict_types=1);
 
 namespace LaravelJsonApi\Eloquent\Fields\Relations;
 
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Enumerable;
 use InvalidArgumentException;
 use LaravelJsonApi\Contracts\Schema\Container;
 use LaravelJsonApi\Contracts\Schema\PolymorphicRelation;
@@ -102,6 +105,19 @@ class MorphToMany extends ToMany implements PolymorphicRelation, IteratorAggrega
                 'JSON:API morph-to-many relation expects to receive JSON:API relation objects.'
             );
         }
+    }
+
+    /**
+     * Get the value of the relationship from the supplied model.
+     *
+     * @param object $model
+     * @return Collection
+     */
+    public function value(object $model): Collection
+    {
+        return collect($this->relations)
+            ->map(fn(Relation $relation) => $model->{$relation->relationName()})
+            ->flatten();
     }
 
 }

--- a/src/Fields/Relations/MorphToMany.php
+++ b/src/Fields/Relations/MorphToMany.php
@@ -74,6 +74,8 @@ class MorphToMany extends ToMany implements PolymorphicRelation, IteratorAggrega
      */
     public function withSchemas(Container $container): void
     {
+        parent::withSchemas($container);
+
         foreach ($this as $relation) {
             $relation->withSchemas($container);
         }

--- a/src/Fields/Relations/Polymorphic.php
+++ b/src/Fields/Relations/Polymorphic.php
@@ -31,11 +31,6 @@ trait Polymorphic
 {
 
     /**
-     * @var array
-     */
-    private array $modelSchemas = [];
-
-    /**
      * Get the inverse schema for the provided model.
      *
      * @param Model $model
@@ -45,14 +40,10 @@ trait Polymorphic
     {
         $class = get_class($model);
 
-        if (isset($this->modelSchemas[$class])) {
-            return $this->modelSchemas[$class];
-        }
-
         /** @var Schema $schema */
         foreach ($this->allSchemas() as $schema) {
             if ($schema->isModel($model)) {
-                return $this->modelSchemas[$class] = $schema;
+                return $schema;
             }
         }
 

--- a/src/Fields/Relations/Polymorphic.php
+++ b/src/Fields/Relations/Polymorphic.php
@@ -1,0 +1,85 @@
+<?php
+/*
+ * Copyright 2021 Cloud Creativity Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+declare(strict_types=1);
+
+namespace LaravelJsonApi\Eloquent\Fields\Relations;
+
+use Generator;
+use Illuminate\Database\Eloquent\Model;
+use LaravelJsonApi\Eloquent\Schema;
+use LogicException;
+use UnexpectedValueException;
+use function get_class;
+use function sprintf;
+
+trait Polymorphic
+{
+
+    /**
+     * @var array
+     */
+    private array $modelSchemas = [];
+
+    /**
+     * Get the inverse schema for the provided model.
+     *
+     * @param Model $model
+     * @return Schema
+     */
+    public function schemaFor(Model $model): Schema
+    {
+        $class = get_class($model);
+
+        if (isset($this->modelSchemas[$class])) {
+            return $this->modelSchemas[$class];
+        }
+
+        /** @var Schema $schema */
+        foreach ($this->allSchemas() as $schema) {
+            if ($schema->isModel($model)) {
+                return $this->modelSchemas[$class] = $schema;
+            }
+        }
+
+        throw new UnexpectedValueException(sprintf(
+            'Model %s is not valid for polymorphic relation %s.',
+            $class,
+            $this->name()
+        ));
+    }
+
+    /**
+     * @return Generator
+     */
+    public function allSchemas(): Generator
+    {
+        foreach ($this->inverseTypes() as $type) {
+            $schema = $this->schemas()->schemaFor($type);
+
+            if ($schema instanceof Schema) {
+                yield $type => $schema;
+                continue;
+            }
+
+            throw new LogicException(sprintf(
+                'Expecting schema for resource type %s to be an Eloquent schema.',
+                $type
+            ));
+        }
+    }
+}

--- a/src/Fields/Relations/Relation.php
+++ b/src/Fields/Relations/Relation.php
@@ -287,12 +287,14 @@ abstract class Relation implements RelationContract, SchemaAwareContract, Serial
      */
     protected function assertInverseType(string $type): void
     {
-        if ($this->inverse() !== $type) {
+        $expected = $this->allInverse();
+
+        if (!in_array($type, $expected, true)) {
             throw new LogicException(sprintf(
                 'Resource type %s is not a valid inverse resource type for relation %s: expecting %s.',
                 $type,
                 $this->name(),
-                $this->inverse()
+                implode(', ', $expected),
             ));
         }
     }

--- a/src/Fields/Relations/ToMany.php
+++ b/src/Fields/Relations/ToMany.php
@@ -24,6 +24,7 @@ use Illuminate\Support\Collection;
 use LaravelJsonApi\Contracts\Pagination\Page;
 use LaravelJsonApi\Core\Support\Str;
 use LaravelJsonApi\Eloquent\Contracts\Proxy;
+use LaravelJsonApi\Eloquent\Polymorphism\MorphMany;
 
 abstract class ToMany extends Relation
 {
@@ -77,6 +78,10 @@ abstract class ToMany extends Relation
      */
     public function parse($models): iterable
     {
+        if ($models instanceof MorphMany) {
+            return $models;
+        }
+
         return $this->schema()->parser()->parseMany(
             $models
         );

--- a/src/Fields/Relations/ToMany.php
+++ b/src/Fields/Relations/ToMany.php
@@ -24,7 +24,6 @@ use Illuminate\Support\Collection;
 use LaravelJsonApi\Contracts\Pagination\Page;
 use LaravelJsonApi\Core\Support\Str;
 use LaravelJsonApi\Eloquent\Contracts\Proxy;
-use LaravelJsonApi\Eloquent\Polymorphism\MorphMany;
 
 abstract class ToMany extends Relation
 {
@@ -78,10 +77,6 @@ abstract class ToMany extends Relation
      */
     public function parse($models): iterable
     {
-        if ($models instanceof MorphMany) {
-            return $models;
-        }
-
         return $this->schema()->parser()->parseMany(
             $models
         );

--- a/src/Hydrators/ToManyHydrator.php
+++ b/src/Hydrators/ToManyHydrator.php
@@ -28,6 +28,7 @@ use LaravelJsonApi\Eloquent\Contracts\FillableToMany;
 use LaravelJsonApi\Eloquent\Contracts\Parser;
 use LaravelJsonApi\Eloquent\Fields\Relations\ToMany;
 use LaravelJsonApi\Eloquent\HasQueryParameters;
+use LaravelJsonApi\Eloquent\Polymorphism\MorphMany;
 use UnexpectedValueException;
 
 class ToManyHydrator implements ToManyBuilder
@@ -108,14 +109,22 @@ class ToManyHydrator implements ToManyBuilder
     }
 
     /**
-     * @param EloquentCollection $related
-     * @return EloquentCollection
+     * Prepare the result for returning.
+     *
+     * @param EloquentCollection|MorphMany $related
+     * @return iterable
      */
-    private function prepareResult(EloquentCollection $related): EloquentCollection
+    private function prepareResult(iterable $related): iterable
     {
         /** Always do eager loading, in case we have default include paths. */
-        if ($related->isNotEmpty()) {
+        if ($related instanceof EloquentCollection && $related->isNotEmpty()) {
             $this->relation->schema()->loader()->forModels($related)->loadMissing(
+                $this->queryParameters->includePaths()
+            );
+        }
+
+        if ($related instanceof MorphMany) {
+            $related->loadMissing(
                 $this->queryParameters->includePaths()
             );
         }

--- a/src/Hydrators/ToManyHydrator.php
+++ b/src/Hydrators/ToManyHydrator.php
@@ -25,7 +25,6 @@ use LaravelJsonApi\Contracts\Store\ToManyBuilder;
 use LaravelJsonApi\Core\Query\QueryParameters;
 use LaravelJsonApi\Core\Support\Str;
 use LaravelJsonApi\Eloquent\Contracts\FillableToMany;
-use LaravelJsonApi\Eloquent\Contracts\Parser;
 use LaravelJsonApi\Eloquent\Fields\Relations\ToMany;
 use LaravelJsonApi\Eloquent\HasQueryParameters;
 use LaravelJsonApi\Eloquent\Polymorphism\MorphMany;
@@ -130,14 +129,6 @@ class ToManyHydrator implements ToManyBuilder
         }
 
         return $related;
-    }
-
-    /**
-     * @return Parser
-     */
-    private function parser(): Parser
-    {
-        return $this->relation->schema()->parser();
     }
 
 }

--- a/src/Hydrators/ToOneHydrator.php
+++ b/src/Hydrators/ToOneHydrator.php
@@ -96,8 +96,7 @@ class ToOneHydrator implements ToOneBuilder
         if ($this->relation instanceof MorphTo) {
             $loader = $this->relation
                 ->schemaFor($related)
-                ->loader()
-                ->skipMissingFields();
+                ->loader();
         } else {
             $loader = $this->relation
                 ->schema()

--- a/src/MorphParameters.php
+++ b/src/MorphParameters.php
@@ -1,0 +1,155 @@
+<?php
+/*
+ * Copyright 2021 Cloud Creativity Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+declare(strict_types=1);
+
+namespace LaravelJsonApi\Eloquent;
+
+use LaravelJsonApi\Contracts\Query\QueryParameters;
+use LaravelJsonApi\Core\Query\FieldSets;
+use LaravelJsonApi\Core\Query\IncludePaths;
+use LaravelJsonApi\Core\Query\RelationshipPath;
+use LaravelJsonApi\Core\Query\SortField;
+use LaravelJsonApi\Core\Query\SortFields;
+
+class MorphParameters implements QueryParameters
+{
+
+    /**
+     * @var Schema
+     */
+    private Schema $schema;
+
+    /**
+     * @var QueryParameters
+     */
+    private QueryParameters $parameters;
+
+    /**
+     * MorphParameters constructor.
+     *
+     * @param Schema $schema
+     * @param QueryParameters $parameters
+     */
+    public function __construct(Schema $schema, QueryParameters $parameters)
+    {
+        $this->schema = $schema;
+        $this->parameters = $parameters;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function includePaths(): ?IncludePaths
+    {
+        if ($paths = $this->parameters->includePaths()) {
+            return new IncludePaths(...collect($paths->all())
+                ->filter(fn($path) => $this->isRelationshipPath($path))
+            );
+        }
+
+        return null;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function sparseFieldSets(): ?FieldSets
+    {
+        return $this->parameters->sparseFieldSets();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function sortFields(): ?SortFields
+    {
+        if ($fields = $this->parameters->sortFields()) {
+            return new SortFields(...collect($fields->all())
+                ->filter(fn($field) => $this->isSortField($field))
+            );
+        }
+
+        return null;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function page(): ?array
+    {
+        return $this->parameters->page();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function filter(): ?array
+    {
+        if (is_array($filters = $this->parameters->filter())) {
+            return collect($filters)
+                ->filter(fn($value, $key) => $this->isFilter($key))
+                ->all();
+        }
+
+        return null;
+    }
+
+    /**
+     * @param RelationshipPath $path
+     * @return bool
+     */
+    private function isRelationshipPath(RelationshipPath $path): bool
+    {
+        if (!$this->schema->isRelationship($path->first())) {
+            return false;
+        }
+
+        return $this->schema->relationship($path->first())->isIncludePath();
+    }
+
+    /**
+     * @param SortField $field
+     * @return bool
+     */
+    private function isSortField(SortField $field): bool
+    {
+        foreach ($this->schema->sortable() as $name) {
+            if ($name === $field->name()) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param string $name
+     * @return bool
+     */
+    private function isFilter(string $name): bool
+    {
+        foreach ($this->schema->filters() as $filter) {
+            if ($filter->key() === $name) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+}

--- a/src/Polymorphism/MorphMany.php
+++ b/src/Polymorphism/MorphMany.php
@@ -1,0 +1,127 @@
+<?php
+/*
+ * Copyright 2021 Cloud Creativity Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+declare(strict_types=1);
+
+namespace LaravelJsonApi\Eloquent\Polymorphism;
+
+use IteratorAggregate;
+
+class MorphMany implements IteratorAggregate, \Countable
+{
+
+    /**
+     * @var MorphValue[]
+     */
+    private array $values;
+
+    /**
+     * MorphMany constructor.
+     *
+     * @param MorphValue ...$values
+     */
+    public function __construct(MorphValue ...$values)
+    {
+        $this->values = $values;
+    }
+
+    /**
+     * @param $relations
+     * @return $this
+     */
+    public function load($relations): self
+    {
+        foreach ($this->values as $value) {
+            $value->load($relations);
+        }
+
+        return $this;
+    }
+
+    /**
+     * @param $relations
+     * @return $this
+     */
+    public function loadMissing($relations): self
+    {
+        foreach ($this->values as $value) {
+            $value->loadMissing($relations);
+        }
+
+        return $this;
+    }
+
+    /**
+     * @param MorphValue $value
+     * @return $this
+     */
+    public function push(MorphValue $value): self
+    {
+        $this->values[] = $value;
+
+        return $this;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isEmpty(): bool
+    {
+        foreach ($this->values as $value) {
+            if ($value->isNotEmpty()) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isNotEmpty(): bool
+    {
+        return !$this->isEmpty();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function count()
+    {
+        $count = 0;
+
+        foreach ($this->values as $value) {
+            $count += $value->count();
+        }
+
+        return $count;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getIterator()
+    {
+        foreach ($this->values as $value) {
+            foreach ($value as $item) {
+                yield $item;
+            }
+        }
+    }
+
+}

--- a/src/Polymorphism/MorphMany.php
+++ b/src/Polymorphism/MorphMany.php
@@ -19,6 +19,7 @@ declare(strict_types=1);
 
 namespace LaravelJsonApi\Eloquent\Polymorphism;
 
+use Illuminate\Support\Collection;
 use IteratorAggregate;
 
 class MorphMany implements IteratorAggregate, \Countable
@@ -74,6 +75,22 @@ class MorphMany implements IteratorAggregate, \Countable
         $this->values[] = $value;
 
         return $this;
+    }
+
+    /**
+     * @return Collection
+     */
+    public function collect(): Collection
+    {
+        return collect($this->all());
+    }
+
+    /**
+     * @return array
+     */
+    public function all(): array
+    {
+        return iterator_to_array($this);
     }
 
     /**

--- a/src/Polymorphism/MorphParameters.php
+++ b/src/Polymorphism/MorphParameters.php
@@ -17,14 +17,14 @@
 
 declare(strict_types=1);
 
-namespace LaravelJsonApi\Eloquent;
+namespace LaravelJsonApi\Eloquent\Polymorphism;
 
 use LaravelJsonApi\Contracts\Query\QueryParameters;
 use LaravelJsonApi\Core\Query\FieldSets;
 use LaravelJsonApi\Core\Query\IncludePaths;
-use LaravelJsonApi\Core\Query\RelationshipPath;
 use LaravelJsonApi\Core\Query\SortField;
 use LaravelJsonApi\Core\Query\SortFields;
+use LaravelJsonApi\Eloquent\Schema;
 
 class MorphParameters implements QueryParameters
 {
@@ -58,7 +58,7 @@ class MorphParameters implements QueryParameters
     {
         if ($paths = $this->parameters->includePaths()) {
             return new IncludePaths(...collect($paths->all())
-                ->filter(fn($path) => $this->isRelationshipPath($path))
+                ->filter(fn($path) => $this->schema->isIncludePath($path))
             );
         }
 
@@ -107,19 +107,6 @@ class MorphParameters implements QueryParameters
         }
 
         return null;
-    }
-
-    /**
-     * @param RelationshipPath $path
-     * @return bool
-     */
-    private function isRelationshipPath(RelationshipPath $path): bool
-    {
-        if (!$this->schema->isRelationship($path->first())) {
-            return false;
-        }
-
-        return $this->schema->relationship($path->first())->isIncludePath();
     }
 
     /**

--- a/src/Polymorphism/MorphValue.php
+++ b/src/Polymorphism/MorphValue.php
@@ -1,0 +1,141 @@
+<?php
+/*
+ * Copyright 2021 Cloud Creativity Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+declare(strict_types=1);
+
+namespace LaravelJsonApi\Eloquent\Polymorphism;
+
+use Countable;
+use Illuminate\Database\Eloquent\Collection as EloquentCollection;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Enumerable;
+use IteratorAggregate;
+use LaravelJsonApi\Eloquent\Fields\Relations\Relation;
+use LaravelJsonApi\Eloquent\Fields\Relations\ToMany;
+use LaravelJsonApi\Eloquent\Fields\Relations\ToOne;
+
+class MorphValue implements IteratorAggregate, Countable
+{
+
+    /**
+     * @var Relation
+     */
+    private Relation $relation;
+
+    /**
+     * @var EloquentCollection|Model|null
+     */
+    private $value;
+
+    /**
+     * MorphValue constructor.
+     *
+     * @param Relation $relation
+     * @param $value
+     */
+    public function __construct(Relation $relation, $value)
+    {
+        $this->relation = $relation;
+        $this->value = $value;
+    }
+
+    /**
+     * @param $includePaths
+     * @return $this
+     */
+    public function load($includePaths): self
+    {
+        if ($this->isNotEmpty()) {
+            $this->relation
+                ->schema()
+                ->loader()
+                ->forModelOrModels($this->value)
+                ->loadIfExists($includePaths);
+        }
+
+        return $this;
+    }
+
+    /**
+     * @param $includePaths
+     * @return $this
+     */
+    public function loadMissing($includePaths): self
+    {
+        if ($this->isNotEmpty()) {
+            $this->relation
+                ->schema()
+                ->loader()
+                ->forModelOrModels($this->value)
+                ->loadMissingIfExists($includePaths);
+        }
+
+        return $this;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isEmpty(): bool
+    {
+        if ($this->value instanceof Enumerable) {
+            return $this->value->isEmpty();
+        }
+
+        return 0 === $this->count();
+    }
+
+    /**
+     * @return bool
+     */
+    public function isNotEmpty(): bool
+    {
+        return !$this->isEmpty();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function count()
+    {
+        if ($this->value instanceof Model) {
+            return 1;
+        }
+
+        if ($this->value instanceof Countable) {
+            return $this->value->count();
+        }
+
+        return 0;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getIterator()
+    {
+        if ($this->relation instanceof ToOne && $this->value) {
+            yield $this->relation->parse($this->value);
+            return;
+        }
+
+        if ($this->relation instanceof ToMany) {
+            yield from $this->relation->parse($this->value);
+        }
+    }
+
+}

--- a/src/QueryMorphTo.php
+++ b/src/QueryMorphTo.php
@@ -121,12 +121,15 @@ class QueryMorphTo implements QueryOneBuilder
     private function prepareResult(?Model $related): ?Model
     {
         if ($related) {
-            $this->relation
-                ->schemaFor($related)
+            $parameters = new MorphParameters(
+                $schema = $this->relation->schemaFor($related),
+                $this->queryParameters,
+            );
+
+            $schema
                 ->loader()
-                ->skipMissingFields()
                 ->forModel($related)
-                ->loadMissing($this->queryParameters->includePaths());
+                ->loadMissing($parameters->includePaths());
         }
 
         return $related;

--- a/src/QueryMorphTo.php
+++ b/src/QueryMorphTo.php
@@ -24,6 +24,7 @@ use LaravelJsonApi\Contracts\Schema\Filter;
 use LaravelJsonApi\Contracts\Store\QueryOneBuilder;
 use LaravelJsonApi\Core\Query\QueryParameters;
 use LaravelJsonApi\Eloquent\Fields\Relations\MorphTo;
+use LaravelJsonApi\Eloquent\Polymorphism\MorphParameters;
 use function is_null;
 
 class QueryMorphTo implements QueryOneBuilder

--- a/src/QueryMorphToMany.php
+++ b/src/QueryMorphToMany.php
@@ -1,0 +1,178 @@
+<?php
+/*
+ * Copyright 2021 Cloud Creativity Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+declare(strict_types=1);
+
+namespace LaravelJsonApi\Eloquent;
+
+use Generator;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Collection;
+use Illuminate\Support\LazyCollection;
+use LaravelJsonApi\Contracts\Pagination\Page;
+use LaravelJsonApi\Contracts\Store\QueryManyBuilder;
+use LaravelJsonApi\Core\Query\QueryParameters;
+use LaravelJsonApi\Eloquent\Fields\Relations\MorphTo;
+use LaravelJsonApi\Eloquent\Fields\Relations\MorphToMany;
+use LaravelJsonApi\Eloquent\Fields\Relations\Relation;
+use LaravelJsonApi\Eloquent\Fields\Relations\ToMany;
+use LaravelJsonApi\Eloquent\Fields\Relations\ToOne;
+use LogicException;
+
+class QueryMorphToMany implements QueryManyBuilder, \IteratorAggregate
+{
+
+    use HasQueryParameters;
+
+    /**
+     * @var Model
+     */
+    private Model $model;
+
+    /**
+     * @var MorphToMany
+     */
+    private MorphToMany $relation;
+
+    /**
+     * QueryMorphToMany constructor.
+     *
+     * @param Model $model
+     * @param MorphToMany $relation
+     */
+    public function __construct(Model $model, MorphToMany $relation)
+    {
+        $this->model = $model;
+        $this->relation = $relation;
+        $this->queryParameters = new QueryParameters();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function filter(?array $filters): QueryManyBuilder
+    {
+        $this->queryParameters->setFilters($filters);
+
+        return $this;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function sort($fields): QueryManyBuilder
+    {
+        $this->queryParameters->setSortFields($fields);
+
+        return $this;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function get(): Collection
+    {
+        return Collection::make($this->values());
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function cursor(): LazyCollection
+    {
+        return LazyCollection::make(function () {
+            yield from $this->values();
+        });
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function paginate(array $page): Page
+    {
+        throw new LogicException('Pagination is not supported on a JSON:API morph-to-many relation.');
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getOrPaginate(?array $page): iterable
+    {
+        if (is_null($page)) {
+            return $this->get();
+        }
+
+        return $this->paginate($page);
+    }
+
+    /**
+     * @return Generator
+     */
+    public function getIterator()
+    {
+        foreach ($this->relation as $relation) {
+            $query = $this->toQuery($relation);
+            $this->request ? $query->withRequest($this->request) : null;
+            yield $query->withQuery($this->queryParameters);
+        }
+    }
+
+    /**
+     * @param Relation $relation
+     * @return QueryMorphTo|QueryToMany|QueryToOne
+     */
+    private function toQuery(Relation $relation)
+    {
+        if ($relation instanceof MorphTo) {
+            return new QueryMorphTo($this->model, $relation);
+        }
+
+        if ($relation instanceof ToOne) {
+            return new QueryToOne($this->model, $relation);
+        }
+
+        if ($relation instanceof ToMany) {
+            return new QueryToMany($this->model, $relation);
+        }
+
+        throw new LogicException(sprintf(
+            'Unsupported relation for querying morph-to-many: %s',
+            get_class($relation),
+        ));
+    }
+
+    /**
+     * @return Generator
+     */
+    private function values(): Generator
+    {
+        /** @var QueryToOne|QueryMorphTo|QueryToMany $query */
+        foreach ($this as $query) {
+            if ($query instanceof QueryToOne || $query instanceof QueryMorphTo) {
+                if ($value = $query->first()) {
+                    yield $value;
+                }
+                continue;
+            }
+
+            foreach ($query->cursor() as $value) {
+                yield $value;
+            }
+        }
+    }
+
+}

--- a/src/QueryMorphToMany.php
+++ b/src/QueryMorphToMany.php
@@ -31,6 +31,7 @@ use LaravelJsonApi\Eloquent\Fields\Relations\MorphToMany;
 use LaravelJsonApi\Eloquent\Fields\Relations\Relation;
 use LaravelJsonApi\Eloquent\Fields\Relations\ToMany;
 use LaravelJsonApi\Eloquent\Fields\Relations\ToOne;
+use LaravelJsonApi\Eloquent\Polymorphism\MorphParameters;
 use LogicException;
 
 class QueryMorphToMany implements QueryManyBuilder, \IteratorAggregate

--- a/src/QueryMorphToMany.php
+++ b/src/QueryMorphToMany.php
@@ -127,7 +127,11 @@ class QueryMorphToMany implements QueryManyBuilder, \IteratorAggregate
         foreach ($this->relation as $relation) {
             $query = $this->toQuery($relation);
             $this->request ? $query->withRequest($this->request) : null;
-            yield $query->withQuery($this->queryParameters);
+
+            yield $query->withQuery(new MorphParameters(
+                $relation->schema(),
+                $this->queryParameters,
+            ));
         }
     }
 

--- a/src/Repository.php
+++ b/src/Repository.php
@@ -40,6 +40,7 @@ use LaravelJsonApi\Eloquent\Contracts\Driver;
 use LaravelJsonApi\Eloquent\Contracts\Parser;
 use LaravelJsonApi\Eloquent\Contracts\Proxy as ProxyContract;
 use LaravelJsonApi\Eloquent\Fields\Relations\MorphTo;
+use LaravelJsonApi\Eloquent\Fields\Relations\MorphToMany;
 use LaravelJsonApi\Eloquent\Hydrators\ModelHydrator;
 use LaravelJsonApi\Eloquent\Hydrators\ToManyHydrator;
 use LaravelJsonApi\Eloquent\Hydrators\ToOneHydrator;
@@ -202,10 +203,14 @@ class Repository implements
      */
     public function queryToMany($modelOrResourceId, string $fieldName): QueryManyBuilder
     {
-        return new QueryToMany(
-            $this->retrieve($modelOrResourceId),
-            $this->schema->toMany($fieldName)
-        );
+        $model = $this->retrieve($modelOrResourceId);
+        $relation = $this->schema->toMany($fieldName);
+
+        if ($relation instanceof MorphToMany) {
+            return new QueryMorphToMany($model, $relation);
+        }
+
+        return new QueryToMany($model, $relation);
     }
 
     /**

--- a/src/Resources/Relation.php
+++ b/src/Resources/Relation.php
@@ -20,6 +20,7 @@ declare(strict_types=1);
 namespace LaravelJsonApi\Eloquent\Resources;
 
 use LaravelJsonApi\Core\Resources\Relation as BaseRelation;
+use LaravelJsonApi\Eloquent\Fields\Relations\MorphToMany;
 use LaravelJsonApi\Eloquent\Fields\Relations\Relation as SchemaRelation;
 
 class Relation extends BaseRelation
@@ -55,6 +56,10 @@ class Relation extends BaseRelation
      */
     protected function value()
     {
+        if ($this->field instanceof MorphToMany) {
+            return $this->field->value($this->resource);
+        }
+
         return $this->field->parse(
             parent::value()
         );

--- a/src/Schema.php
+++ b/src/Schema.php
@@ -24,6 +24,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Http\Request;
 use LaravelJsonApi\Contracts\Store\Repository as RepositoryContract;
+use LaravelJsonApi\Core\Query\RelationshipPath;
 use LaravelJsonApi\Core\Schema\Schema as BaseSchema;
 use LaravelJsonApi\Eloquent\Contracts\Driver;
 use LaravelJsonApi\Eloquent\Contracts\Parser;
@@ -268,6 +269,21 @@ abstract class Schema extends BaseSchema
         }
 
         return $this->parser = new StandardParser();
+    }
+
+    /**
+     * @param RelationshipPath $path
+     * @return bool
+     */
+    public function isIncludePath(RelationshipPath $path): bool
+    {
+        if (!$this->isRelationship($path->first())) {
+            return false;
+        }
+
+        return $this
+            ->relationship($path->first())
+            ->isIncludePath();
     }
 
     /**

--- a/tests/app/Models/Post.php
+++ b/tests/app/Models/Post.php
@@ -22,6 +22,7 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Illuminate\Database\Eloquent\Relations\MorphOne;
 use Illuminate\Database\Eloquent\Relations\MorphToMany;
@@ -67,6 +68,14 @@ class Post extends Model
     }
 
     /**
+     * @return BelongsToMany
+     */
+    public function images(): BelongsToMany
+    {
+        return $this->belongsToMany(Image::class);
+    }
+
+    /**
      * @return MorphToMany
      */
     public function tags(): MorphToMany
@@ -74,6 +83,14 @@ class Post extends Model
         return $this
             ->morphToMany(Tag::class, 'taggable')
             ->withPivot('approved');
+    }
+
+    /**
+     * @return BelongsToMany
+     */
+    public function videos(): BelongsToMany
+    {
+        return $this->belongsToMany(Video::class);
     }
 
     /**

--- a/tests/app/Models/Video.php
+++ b/tests/app/Models/Video.php
@@ -41,6 +41,11 @@ class Video extends Model
     protected $primaryKey = 'uuid';
 
     /**
+     * @var string
+     */
+    protected $keyType = 'string';
+
+    /**
      * @var string[]
      */
     protected $fillable = [

--- a/tests/app/Schemas/PostSchema.php
+++ b/tests/app/Schemas/PostSchema.php
@@ -27,12 +27,12 @@ use LaravelJsonApi\Eloquent\Fields\Relations\BelongsTo;
 use LaravelJsonApi\Eloquent\Fields\Relations\BelongsToMany;
 use LaravelJsonApi\Eloquent\Fields\Relations\HasMany;
 use LaravelJsonApi\Eloquent\Fields\Relations\HasOne;
+use LaravelJsonApi\Eloquent\Fields\Relations\MorphToMany;
 use LaravelJsonApi\Eloquent\Fields\SoftDelete;
 use LaravelJsonApi\Eloquent\Fields\Str;
 use LaravelJsonApi\Eloquent\Filters\OnlyTrashed;
 use LaravelJsonApi\Eloquent\Filters\Where;
 use LaravelJsonApi\Eloquent\Filters\WhereIn;
-use LaravelJsonApi\Eloquent\Filters\WhereTrashed;
 use LaravelJsonApi\Eloquent\Filters\WithTrashed;
 use LaravelJsonApi\Eloquent\Pagination\PagePagination;
 use LaravelJsonApi\Eloquent\Schema;
@@ -68,6 +68,10 @@ class PostSchema extends Schema
             Str::make('content'),
             SoftDelete::make('deletedAt')->sortable(),
             HasOne::make('image'),
+            MorphToMany::make('media', [
+                BelongsToMany::make('images'),
+                BelongsToMany::make('videos'),
+            ]),
             Str::make('slug')->sortable(),
             BelongsToMany::make('tags')->fields(new ApprovedPivot()),
             Str::make('title'),

--- a/tests/app/Schemas/VideoSchema.php
+++ b/tests/app/Schemas/VideoSchema.php
@@ -46,7 +46,7 @@ class VideoSchema extends Schema
     public function fields(): iterable
     {
         return [
-            ID::make()->uuid(),
+            ID::make()->uuid()->sortable(),
             DateTime::make('createdAt')->sortable()->readOnly(),
             HasMany::make('comments'),
             Str::make('slug'),

--- a/tests/database/migrations/2020_11_10_0953_create_post_and_video_tables.php
+++ b/tests/database/migrations/2020_11_10_0953_create_post_and_video_tables.php
@@ -100,6 +100,42 @@ class CreatePostAndVideoTables extends Migration
                 ->cascadeOnDelete()
                 ->cascadeOnUpdate();
         });
+
+        Schema::create('image_post', function (Blueprint $table) {
+            $table->unsignedBigInteger('image_id');
+            $table->unsignedBigInteger('post_id');
+            $table->primary(['image_id', 'post_id']);
+
+            $table->foreign('image_id')
+                ->references('id')
+                ->on('images')
+                ->cascadeOnDelete()
+                ->cascadeOnUpdate();
+
+            $table->foreign('post_id')
+                ->references('id')
+                ->on('posts')
+                ->cascadeOnDelete()
+                ->cascadeOnUpdate();
+        });
+
+        Schema::create('post_video', function (Blueprint $table) {
+            $table->unsignedBigInteger('post_id');
+            $table->uuid('video_uuid');
+            $table->primary(['post_id', 'video_uuid']);
+
+            $table->foreign('post_id')
+                ->references('id')
+                ->on('posts')
+                ->cascadeOnDelete()
+                ->cascadeOnUpdate();
+
+            $table->foreign('video_uuid')
+                ->references('uuid')
+                ->on('videos')
+                ->cascadeOnDelete()
+                ->cascadeOnUpdate();
+        });
     }
 
     /**

--- a/tests/lib/Acceptance/EagerLoading/EagerLoadPathListTest.php
+++ b/tests/lib/Acceptance/EagerLoading/EagerLoadPathListTest.php
@@ -1,0 +1,91 @@
+<?php
+/*
+ * Copyright 2021 Cloud Creativity Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+declare(strict_types=1);
+
+namespace LaravelJsonApi\Eloquent\Tests\Acceptance\EagerLoading;
+
+use LaravelJsonApi\Core\Query\RelationshipPath;
+use LaravelJsonApi\Eloquent\EagerLoading\EagerLoadPathList;
+use LaravelJsonApi\Eloquent\Tests\Acceptance\TestCase;
+
+class EagerLoadPathListTest extends TestCase
+{
+
+    public function test(): void
+    {
+        $path = new EagerLoadPathList(
+            $this->schemas()->schemaFor('posts'),
+            RelationshipPath::fromString('author.country'),
+        );
+
+        $this->assertSame(['user.country'], iterator_to_array($path->paths()));
+    }
+
+    public function testMorphTo1(): void
+    {
+        $path = new EagerLoadPathList(
+            $this->schemas()->schemaFor('posts'),
+            RelationshipPath::fromString('image.imageable')
+        );
+
+        $this->assertSame(['image.imageable'], iterator_to_array($path->paths()));
+    }
+
+    public function testMorphTo2(): void
+    {
+        $path = new EagerLoadPathList(
+            $this->schemas()->schemaFor('posts'),
+            RelationshipPath::fromString('image.imageable.phone'),
+        );
+
+        $this->assertSame(['image.imageable'], iterator_to_array($path->paths()));
+    }
+
+    public function testMorphToMany1(): void
+    {
+        $path = new EagerLoadPathList(
+            $this->schemas()->schemaFor('posts'),
+            RelationshipPath::fromString('media'),
+        );
+
+        $this->assertSame(['images', 'videos'], iterator_to_array($path->paths()));
+    }
+
+    public function testMorphToMany2(): void
+    {
+        $path = new EagerLoadPathList(
+            $this->schemas()->schemaFor('posts'),
+            RelationshipPath::fromString('media.imageable'),
+        );
+
+        $this->assertSame(['images.imageable', 'videos'], iterator_to_array($path->paths()));
+    }
+
+    public function testMorphToMany3(): void
+    {
+        $path = new EagerLoadPathList(
+            $this->schemas()->schemaFor('countries'),
+            RelationshipPath::fromString('posts.media.imageable')
+        );
+
+        $this->assertSame([
+            'posts.images.imageable',
+            'posts.videos',
+        ], iterator_to_array($path->paths()));
+    }
+}

--- a/tests/lib/Acceptance/EagerLoading/EagerLoaderTest.php
+++ b/tests/lib/Acceptance/EagerLoading/EagerLoaderTest.php
@@ -17,11 +17,12 @@
 
 declare(strict_types=1);
 
-namespace LaravelJsonApi\Eloquent\Tests\Acceptance;
+namespace LaravelJsonApi\Eloquent\Tests\Acceptance\EagerLoading;
 
 use App\Models\Post;
 use App\Models\User;
 use App\Schemas\PostSchema;
+use LaravelJsonApi\Eloquent\Tests\Acceptance\TestCase;
 
 class EagerLoaderTest extends TestCase
 {
@@ -42,6 +43,11 @@ class EagerLoaderTest extends TestCase
                 'author.country,comments.user.country,image.imageable',
                 // return values are sorted
                 ['comments.user.country', 'image.imageable', 'user.country'],
+            ],
+            'posts morph-to-many' => [
+                'posts',
+                'media.imageable,media.comments',
+                ['images.imageable', 'videos.comments'],
             ],
             'tags' => [
                 'tags',

--- a/tests/lib/Acceptance/Relations/PolymorphicToMany/AttachTest.php
+++ b/tests/lib/Acceptance/Relations/PolymorphicToMany/AttachTest.php
@@ -1,0 +1,119 @@
+<?php
+/*
+ * Copyright 2021 Cloud Creativity Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+declare(strict_types=1);
+
+namespace LaravelJsonApi\Eloquent\Tests\Acceptance\Relations\PolymorphicToMany;
+
+use App\Models\Image;
+use App\Models\Post;
+use App\Models\Video;
+use LaravelJsonApi\Eloquent\Polymorphism\MorphMany;
+
+class AttachTest extends TestCase
+{
+
+    public function test(): void
+    {
+        $post = Post::factory()
+            ->has(Image::factory()->count(1))
+            ->has(Video::factory()->count(1))
+            ->create();
+
+        $add = collect([
+            Image::factory()->create(),
+            Video::factory()->create(),
+        ]);
+
+        $expectedImages = collect([
+            $post->images()->first(),
+            $add[0],
+        ]);
+
+        $expectedVideos = collect([
+            $post->videos()->first(),
+            $add[1],
+        ]);
+
+        $ids = $add->map(fn($model) => [
+            'type' => ($model instanceof Image) ? 'images' : 'videos',
+            'id' => (string) $model->getRouteKey(),
+        ])->all();
+
+        $actual = $this->repository->modifyToMany($post, 'media')->attach($ids);
+
+        /**
+         * We expect the relation to be unloaded because we know it has changed in the
+         * database, but we don't know what it now is in its entirety.
+         */
+        $this->assertFalse($post->relationLoaded('images'));
+        $this->assertFalse($post->relationLoaded('videos'));
+
+        $this->assertInstanceOf(MorphMany::class, $actual);
+        $this->assertMedia($add, $actual);
+
+        $this->assertDatabaseCount('image_post', count($expectedImages));
+        $this->assertDatabaseCount('post_video', count($expectedVideos));
+
+        foreach ($expectedImages as $image) {
+            $this->assertDatabaseHas('image_post', [
+                'image_id' => $image->getKey(),
+                'post_id' => $post->getKey(),
+            ]);
+        }
+
+        foreach ($expectedVideos as $video) {
+            $this->assertDatabaseHas('post_video', [
+                'post_id' => $post->getKey(),
+                'video_uuid' => $video->getKey(),
+            ]);
+        }
+    }
+
+    public function testWithIncludePaths(): void
+    {
+        $post = Post::factory()
+            ->has(Image::factory()->count(1))
+            ->has(Video::factory()->count(1))
+            ->create();
+
+        $add = collect([
+            Image::factory()->create(),
+            Video::factory()->create(),
+        ]);
+
+        $ids = $add->map(fn($model) => [
+            'type' => ($model instanceof Image) ? 'images' : 'videos',
+            'id' => (string) $model->getRouteKey(),
+        ])->all();
+
+        $actual = $this->repository
+            ->modifyToMany($post, 'media')
+            ->with(['imageable', 'comments'])
+            ->attach($ids);
+
+        $this->assertMedia($add, $actual);
+
+        $this->assertTrue(collect($actual)
+            ->whereInstanceOf(Image::class)
+            ->every(fn(Image $image) => $image->relationLoaded('imageable')));
+
+        $this->assertTrue(collect($actual)
+            ->whereInstanceOf(Video::class)
+            ->every(fn(Video $video) => $video->relationLoaded('comments')));
+    }
+}

--- a/tests/lib/Acceptance/Relations/PolymorphicToMany/CreateTest.php
+++ b/tests/lib/Acceptance/Relations/PolymorphicToMany/CreateTest.php
@@ -1,0 +1,100 @@
+<?php
+/*
+ * Copyright 2021 Cloud Creativity Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+declare(strict_types=1);
+
+namespace LaravelJsonApi\Eloquent\Tests\Acceptance\Relations\PolymorphicToMany;
+
+use App\Models\Image;
+use App\Models\Post;
+use App\Models\User;
+use App\Models\Video;
+
+class CreateTest extends TestCase
+{
+
+    /**
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Post::creating(function (Post $post) {
+            $post->user()->associate(User::factory()->create());
+        });
+    }
+
+    public function test(): void
+    {
+        $images = Image::factory()->count(2)->create();
+        $videos = Video::factory()->count(2)->create();
+
+        $expected = collect($images)->merge($videos);
+
+        $ids = $expected->map(fn($model) => [
+            'type' => ($model instanceof Image) ? 'images' : 'videos',
+            'id' => (string) $model->getRouteKey(),
+        ])->all();
+
+        $post = $this->repository->create()->store([
+            'content' => '...',
+            'media' => $ids,
+            'slug' => 'hello-world',
+            'title' => 'Hello World',
+        ]);
+
+        $this->assertTrue($post->relationLoaded('images'));
+        $this->assertTrue($post->relationLoaded('videos'));
+
+        $this->assertImages($images, $post->images);
+        $this->assertVideos($videos, $post->videos);
+
+        $this->assertDatabaseCount('image_post', count($images));
+        $this->assertDatabaseCount('post_video', count($videos));
+
+        foreach ($images as $image) {
+            $this->assertDatabaseHas('image_post', [
+                'image_id' => $image->getKey(),
+                'post_id' => $post->getKey(),
+            ]);
+        }
+
+        foreach ($videos as $video) {
+            $this->assertDatabaseHas('post_video', [
+                'post_id' => $post->getKey(),
+                'video_uuid' => $video->getKey(),
+            ]);
+        }
+    }
+
+    public function testEmpty(): void
+    {
+        $post = $this->repository->create()->store([
+            'content' => '...',
+            'media' => [],
+            'slug' => 'hello-world',
+            'title' => 'Hello World',
+        ]);
+
+        $this->assertTrue($post->relationLoaded('images'));
+        $this->assertTrue($post->relationLoaded('videos'));
+
+        $this->assertEmpty($post->images);
+        $this->assertEmpty($post->videos);
+    }
+}

--- a/tests/lib/Acceptance/Relations/PolymorphicToMany/DetachTest.php
+++ b/tests/lib/Acceptance/Relations/PolymorphicToMany/DetachTest.php
@@ -1,0 +1,132 @@
+<?php
+/*
+ * Copyright 2021 Cloud Creativity Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+declare(strict_types=1);
+
+namespace LaravelJsonApi\Eloquent\Tests\Acceptance\Relations\PolymorphicToMany;
+
+use App\Models\Image;
+use App\Models\Post;
+use App\Models\Video;
+use LaravelJsonApi\Eloquent\Polymorphism\MorphMany;
+
+class DetachTest extends TestCase
+{
+
+    public function test(): void
+    {
+        $post = Post::factory()
+            ->has(Image::factory()->count(3))
+            ->has(Video::factory()->count(3))
+            ->create();
+
+        $existingImages = $post->images()->get();
+        $existingVideos = $post->videos()->get();
+
+        $removeImages = $existingImages->take(2);
+        $removeVideos = $existingVideos->take(1);
+
+        $keepImages = collect([$existingImages->last()]);
+        $keepVideos = $existingVideos->skip(1);
+
+        $detach = collect($removeImages)->merge($removeVideos);
+
+        $ids = $detach->map(fn($model) => [
+            'type' => ($model instanceof Image) ? 'images' : 'videos',
+            'id' => (string) $model->getRouteKey(),
+        ])->all();
+
+        $actual = $this->repository->modifyToMany($post, 'media')->detach($ids);
+
+        /**
+         * We expect the relation to be unloaded because we know it has changed in the
+         * database, but we don't know what it now is in its entirety.
+         */
+        $this->assertFalse($post->relationLoaded('images'));
+        $this->assertFalse($post->relationLoaded('videos'));
+
+        $this->assertInstanceOf(MorphMany::class, $actual);
+        $this->assertMedia($detach, $actual);
+
+        $this->assertDatabaseCount('image_post', count($existingImages) - count($removeImages));
+        $this->assertDatabaseCount('post_video', count($existingVideos) - count($removeVideos));
+
+        foreach ($keepImages as $image) {
+            $this->assertDatabaseHas('image_post', [
+                'image_id' => $image->getKey(),
+                'post_id' => $post->getKey(),
+            ]);
+        }
+
+        foreach ($removeImages as $image) {
+            $this->assertDatabaseMissing('image_post', [
+                'image_id' => $image->getKey(),
+                'post_id' => $post->getKey(),
+            ]);
+        }
+
+        foreach ($keepVideos as $video) {
+            $this->assertDatabaseHas('post_video', [
+                'post_id' => $post->getKey(),
+                'video_uuid' => $video->getKey(),
+            ]);
+        }
+
+        foreach ($removeVideos as $video) {
+            $this->assertDatabaseMissing('post_video', [
+                'post_id' => $post->getKey(),
+                'video_uuid' => $video->getKey(),
+            ]);
+        }
+    }
+
+    public function testWithIncludePaths(): void
+    {
+        $post = Post::factory()
+            ->has(Image::factory()->count(3))
+            ->has(Video::factory()->count(3))
+            ->create();
+
+        $existingImages = $post->images()->get();
+        $existingVideos = $post->videos()->get();
+
+        $removeImages = $existingImages->take(2);
+        $removeVideos = $existingVideos->take(1);
+
+        $detach = collect($removeImages)->merge($removeVideos);
+
+        $ids = $detach->map(fn($model) => [
+            'type' => ($model instanceof Image) ? 'images' : 'videos',
+            'id' => (string) $model->getRouteKey(),
+        ])->all();
+
+        $actual = $this->repository
+            ->modifyToMany($post, 'media')
+            ->with(['imageable', 'comments'])
+            ->detach($ids);
+
+        $this->assertMedia($detach, $actual);
+
+        $this->assertTrue(collect($actual)
+            ->whereInstanceOf(Image::class)
+            ->every(fn(Image $image) => $image->relationLoaded('imageable')));
+
+        $this->assertTrue(collect($actual)
+            ->whereInstanceOf(Video::class)
+            ->every(fn(Video $video) => $video->relationLoaded('comments')));
+    }
+}

--- a/tests/lib/Acceptance/Relations/PolymorphicToMany/QueryTest.php
+++ b/tests/lib/Acceptance/Relations/PolymorphicToMany/QueryTest.php
@@ -22,6 +22,8 @@ namespace LaravelJsonApi\Eloquent\Tests\Acceptance\Relations\PolymorphicToMany;
 use App\Models\Image;
 use App\Models\Post;
 use App\Models\Video;
+use App\Schemas\VideoSchema;
+use Illuminate\Database\Eloquent\Model;
 
 class QueryTest extends TestCase
 {
@@ -73,5 +75,107 @@ class QueryTest extends TestCase
             $actual->whereInstanceOf(Video::class)->every(fn(Video $video) => $video->relationLoaded('comments')),
             'videos'
         );
+    }
+
+    public function testDefaultEagerLoading(): void
+    {
+        $this->createSchemaWithDefaultEagerLoading(VideoSchema::class, 'comments');
+
+        $post = Post::factory()
+            ->has(Image::factory()->count(3))
+            ->has(Video::factory()->count(3))
+            ->create();
+
+        $expected = $post->images()->get()->merge(
+            $post->videos()->get()
+        );
+
+        $actual = $this->repository
+            ->queryToMany($post, 'media')
+            ->get();
+
+        $this->assertCount(6, $actual);
+        $this->assertMedia($expected, $actual);
+
+        $this->assertTrue(
+            $actual->whereInstanceOf(Video::class)->every(fn(Video $video) => $video->relationLoaded('comments')),
+            'videos'
+        );
+    }
+
+    public function testDefaultEagerLoadingAndIncludePaths(): void
+    {
+        $this->createSchemaWithDefaultEagerLoading(VideoSchema::class, 'comments');
+
+        $post = Post::factory()
+            ->has(Image::factory()->count(3))
+            ->has(Video::factory()->count(3))
+            ->create();
+
+        $expected = $post->images()->get()->merge(
+            $post->videos()->get()
+        );
+
+        $actual = $this->repository
+            ->queryToMany($post, 'media')
+            ->with(['imageable'])
+            ->get();
+
+        $this->assertCount(6, $actual);
+        $this->assertMedia($expected, $actual);
+
+        $this->assertTrue(
+            $actual->whereInstanceOf(Image::class)->every(fn(Image $image) => $image->relationLoaded('imageable')),
+            'images'
+        );
+
+        $this->assertTrue(
+            $actual->whereInstanceOf(Video::class)->every(fn(Video $video) => $video->relationLoaded('comments')),
+            'videos'
+        );
+    }
+
+    public function testWithFilter(): void
+    {
+        $post = Post::factory()
+            ->has(Image::factory()->count(3))
+            ->has(Video::factory()->count(3))
+            ->create();
+
+        $expected = $post->images()->take(2)->get()->merge(
+            $post->videos()->take(1)->get()
+        );
+
+        $ids = $expected
+            ->map(fn(Model $model) => (string) $model->getRouteKey())
+            ->all();
+
+        $actual = $this->repository
+            ->queryToMany($post, 'media')
+            ->filter(['id' => $ids])
+            ->get();
+
+        $this->assertCount(3, $actual);
+        $this->assertMedia($expected, $actual);
+    }
+
+    public function testWithSort(): void
+    {
+        $post = Post::factory()
+            ->has(Image::factory()->count(3))
+            ->has(Video::factory()->count(3))
+            ->create();
+
+        $expected = $post->images()->get()->sortByDesc('id')->values()->merge(
+            $post->videos()->get()->sortByDesc('uuid')->values()
+        );
+
+        $actual = $this->repository
+            ->queryToMany($post, 'media')
+            ->sort('-id')
+            ->cursor();
+
+        $this->assertCount(6, $actual);
+        $this->assertMedia($expected, $actual);
     }
 }

--- a/tests/lib/Acceptance/Relations/PolymorphicToMany/QueryTest.php
+++ b/tests/lib/Acceptance/Relations/PolymorphicToMany/QueryTest.php
@@ -1,0 +1,47 @@
+<?php
+/*
+ * Copyright 2021 Cloud Creativity Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+declare(strict_types=1);
+
+namespace LaravelJsonApi\Eloquent\Tests\Acceptance\Relations\PolymorphicToMany;
+
+use App\Models\Image;
+use App\Models\Post;
+use App\Models\Video;
+
+class QueryTest extends TestCase
+{
+
+    public function test(): void
+    {
+        $post = Post::factory()
+            ->has(Image::factory()->count(3))
+            ->has(Video::factory()->count(3))
+            ->create();
+
+        $expected = $post->images()->get()->merge(
+            $post->videos()->get()
+        );
+
+        $actual = $this->repository
+            ->queryToMany($post, 'media')
+            ->cursor();
+
+        $this->assertCount(6, $actual);
+        $this->assertMedia($expected, $actual);
+    }
+}

--- a/tests/lib/Acceptance/Relations/PolymorphicToMany/SyncTest.php
+++ b/tests/lib/Acceptance/Relations/PolymorphicToMany/SyncTest.php
@@ -1,0 +1,152 @@
+<?php
+/*
+ * Copyright 2021 Cloud Creativity Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+declare(strict_types=1);
+
+namespace LaravelJsonApi\Eloquent\Tests\Acceptance\Relations\PolymorphicToMany;
+
+use App\Models\Image;
+use App\Models\Post;
+use App\Models\Video;
+use LaravelJsonApi\Eloquent\Polymorphism\MorphMany;
+
+class SyncTest extends TestCase
+{
+
+    public function test(): void
+    {
+        $post = Post::factory()
+            ->has(Image::factory()->count(3))
+            ->has(Video::factory()->count(3))
+            ->create();
+
+        $existingImages = $post->images()->get();
+        $existingVideos = $post->videos()->get();
+
+        $removeImage = $existingImages->last();
+        $removeVideo = $existingVideos->last();
+
+        $expectedImages = $existingImages->take(2)->push(Image::factory()->create());
+        $expectedVideos = $existingVideos->take(2)->push(Video::factory()->create());
+
+        $expected = collect($expectedImages)->merge($expectedVideos);
+
+        $ids = $expected->map(fn($model) => [
+            'type' => ($model instanceof Image) ? 'images' : 'videos',
+            'id' => (string) $model->getRouteKey(),
+        ])->all();
+
+        $actual = $this->repository->modifyToMany($post, 'media')->sync($ids);
+
+        $this->assertTrue($post->relationLoaded('images'));
+        $this->assertTrue($post->relationLoaded('videos'));
+
+        $this->assertImages($expectedImages, $post->images);
+        $this->assertVideos($expectedVideos, $post->videos);
+
+        $this->assertInstanceOf(MorphMany::class, $actual);
+        $this->assertMedia($expected, $actual);
+
+        $this->assertDatabaseCount('image_post', count($expectedImages));
+        $this->assertDatabaseCount('post_video', count($expectedVideos));
+
+        foreach ($expectedImages as $image) {
+            $this->assertDatabaseHas('image_post', [
+                'image_id' => $image->getKey(),
+                'post_id' => $post->getKey(),
+            ]);
+        }
+
+        $this->assertDatabaseMissing('image_post', [
+            'image_id' => $removeImage->getKey(),
+            'post_id' => $post->getKey(),
+        ]);
+
+        foreach ($expectedVideos as $video) {
+            $this->assertDatabaseHas('post_video', [
+                'post_id' => $post->getKey(),
+                'video_uuid' => $video->getKey(),
+            ]);
+        }
+
+        $this->assertDatabaseMissing('post_video', [
+            'post_id' => $post->getKey(),
+            'video_uuid' => $removeVideo->getKey(),
+        ]);
+    }
+
+    public function testEmpty(): void
+    {
+        $post = Post::factory()
+            ->has(Image::factory()->count(3))
+            ->has(Video::factory()->count(3))
+            ->create();
+
+        $actual = $this->repository
+            ->modifyToMany($post, 'media')
+            ->sync([]);
+
+        $this->assertCount(0, $actual);
+
+        $this->assertTrue($post->relationLoaded('images'));
+        $this->assertCount(0, $post->images);
+
+        $this->assertTrue($post->relationLoaded('videos'));
+        $this->assertCount(0, $post->videos);
+
+        $this->assertDatabaseCount('image_post', 0);
+        $this->assertDatabaseCount('post_video', 0);
+    }
+
+    public function testWithIncludePaths(): void
+    {
+        $post = Post::factory()
+            ->has(Image::factory()->count(3))
+            ->has(Video::factory()->count(3))
+            ->create();
+
+        $existingImages = $post->images()->get();
+        $existingVideos = $post->videos()->get();
+
+        $expectedImages = $existingImages->take(2)->push(Image::factory()->create());
+        $expectedVideos = $existingVideos->take(2)->push(Video::factory()->create());
+
+        $expected = collect($expectedImages)->merge($expectedVideos);
+
+        $ids = $expected->map(fn($model) => [
+            'type' => ($model instanceof Image) ? 'images' : 'videos',
+            'id' => (string) $model->getRouteKey(),
+        ])->all();
+
+        $actual = $this->repository
+            ->modifyToMany($post, 'media')
+            ->with(['imageable', 'comments'])
+            ->sync($ids);
+
+        $this->assertImages($expectedImages, $post->images);
+        $this->assertVideos($expectedVideos, $post->videos);
+        $this->assertMedia($expected, $actual);
+
+        $this->assertTrue(collect($actual)
+            ->whereInstanceOf(Image::class)
+            ->every(fn(Image $image) => $image->relationLoaded('imageable')));
+
+        $this->assertTrue(collect($actual)
+            ->whereInstanceOf(Video::class)
+            ->every(fn(Video $video) => $video->relationLoaded('comments')));
+    }
+}

--- a/tests/lib/Acceptance/Relations/PolymorphicToMany/TestCase.php
+++ b/tests/lib/Acceptance/Relations/PolymorphicToMany/TestCase.php
@@ -19,6 +19,8 @@ declare(strict_types=1);
 
 namespace LaravelJsonApi\Eloquent\Tests\Acceptance\Relations\PolymorphicToMany;
 
+use App\Models\Image;
+use App\Models\Video;
 use Illuminate\Database\Eloquent\Model;
 use LaravelJsonApi\Eloquent\Repository;
 use LaravelJsonApi\Eloquent\Tests\Acceptance\TestCase as BaseTestCase;
@@ -45,14 +47,51 @@ class TestCase extends BaseTestCase
      * @param $actual
      * @return void
      */
-    protected function assertMedia($expected, $actual): void
+    protected function assertImages($expected, $actual): void
     {
         $expected = collect($expected)
-            ->map($fn = fn(Model $model) => [get_class($model), $model->getKey()])
+            ->map($fn = fn(Image $model) => $model->getKey())
+            ->sort()
             ->values()
             ->all();
 
-        $actual = collect($actual)->map($fn)->values()->all();
+        $actual = collect($actual)->map($fn)->sort()->values()->all();
+
+        $this->assertSame($expected, $actual);
+    }
+
+    /**
+     * @param $expected
+     * @param $actual
+     * @return void
+     */
+    protected function assertVideos($expected, $actual): void
+    {
+        $expected = collect($expected)
+            ->map($fn = fn(Video $model) => $model->getKey())
+            ->sort()
+            ->values()
+            ->all();
+
+        $actual = collect($actual)->map($fn)->sort()->values()->all();
+
+        $this->assertSame($expected, $actual);
+    }
+
+    /**
+     * @param $expected
+     * @param $actual
+     * @return void
+     */
+    protected function assertMedia($expected, $actual): void
+    {
+        $expected = collect($expected)
+            ->sortBy($sort = fn(Model $model) => $model->getKey())
+            ->map($map = fn(Model $model) => [get_class($model), $model->getKey()])
+            ->values()
+            ->all();
+
+        $actual = collect($actual)->sortBy($sort)->map($map)->values()->all();
 
         $this->assertSame($expected, $actual);
     }

--- a/tests/lib/Acceptance/Relations/PolymorphicToMany/TestCase.php
+++ b/tests/lib/Acceptance/Relations/PolymorphicToMany/TestCase.php
@@ -1,0 +1,59 @@
+<?php
+/*
+ * Copyright 2021 Cloud Creativity Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+declare(strict_types=1);
+
+namespace LaravelJsonApi\Eloquent\Tests\Acceptance\Relations\PolymorphicToMany;
+
+use Illuminate\Database\Eloquent\Model;
+use LaravelJsonApi\Eloquent\Repository;
+use LaravelJsonApi\Eloquent\Tests\Acceptance\TestCase as BaseTestCase;
+
+class TestCase extends BaseTestCase
+{
+
+    /**
+     * @var Repository
+     */
+    protected Repository $repository;
+
+    /**
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->repository = $this->schemas()->schemaFor('posts')->repository();
+    }
+
+    /**
+     * @param $expected
+     * @param $actual
+     * @return void
+     */
+    protected function assertMedia($expected, $actual): void
+    {
+        $expected = collect($expected)
+            ->map($fn = fn(Model $model) => [get_class($model), $model->getKey()])
+            ->values()
+            ->all();
+
+        $actual = collect($actual)->map($fn)->values()->all();
+
+        $this->assertSame($expected, $actual);
+    }
+}

--- a/tests/lib/Acceptance/Relations/PolymorphicToMany/UpdateTest.php
+++ b/tests/lib/Acceptance/Relations/PolymorphicToMany/UpdateTest.php
@@ -1,0 +1,99 @@
+<?php
+/*
+ * Copyright 2021 Cloud Creativity Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+declare(strict_types=1);
+
+namespace LaravelJsonApi\Eloquent\Tests\Acceptance\Relations\PolymorphicToMany;
+
+use App\Models\Image;
+use App\Models\Post;
+use App\Models\Video;
+
+class UpdateTest extends TestCase
+{
+
+    public function test(): void
+    {
+        $post = Post::factory()
+            ->has(Image::factory()->count(3))
+            ->has(Video::factory()->count(3))
+            ->create();
+
+        $existingImages = $post->images()->get();
+        $existingVideos = $post->videos()->get();
+
+        $expectedImages = $existingImages->take(2)->push(Image::factory()->create());
+        $expectedVideos = $existingVideos->skip(1)->push(Video::factory()->create());
+
+        $expected = collect($expectedImages)->merge($expectedVideos);
+
+        $ids = $expected->map(fn($model) => [
+            'type' => ($model instanceof Image) ? 'images' : 'videos',
+            'id' => (string) $model->getRouteKey(),
+        ])->all();
+
+        $this->repository->update($post)->store([
+            'title' => 'Hello World',
+            'media' => $ids,
+        ]);
+
+        $this->assertTrue($post->relationLoaded('images'));
+        $this->assertTrue($post->relationLoaded('videos'));
+
+        $this->assertImages($expectedImages, $post->images);
+        $this->assertVideos($expectedVideos, $post->videos);
+
+        $this->assertDatabaseCount('image_post', count($expectedImages));
+        $this->assertDatabaseCount('post_video', count($expectedVideos));
+
+        foreach ($expectedImages as $image) {
+            $this->assertDatabaseHas('image_post', [
+                'image_id' => $image->getKey(),
+                'post_id' => $post->getKey(),
+            ]);
+        }
+
+        foreach ($expectedVideos as $video) {
+            $this->assertDatabaseHas('post_video', [
+                'post_id' => $post->getKey(),
+                'video_uuid' => $video->getKey(),
+            ]);
+        }
+    }
+
+    public function testEmpty(): void
+    {
+        $post = Post::factory()
+            ->has(Image::factory()->count(1))
+            ->has(Video::factory()->count(1))
+            ->create();
+
+        $this->repository->update($post)->store([
+            'title' => 'Hello World',
+            'media' => [],
+        ]);
+
+        $this->assertTrue($post->relationLoaded('images'));
+        $this->assertTrue($post->relationLoaded('videos'));
+
+        $this->assertEmpty($post->images);
+        $this->assertEmpty($post->videos);
+
+        $this->assertDatabaseCount('image_post', 0);
+        $this->assertDatabaseCount('post_video', 0);
+    }
+}


### PR DESCRIPTION
Adds a `MorphToMany` relation field, that effectively wraps multiple relation fields, for example:

```php
MorphToMany::make('media', [
    BelongsToMany::make('images'),
    BelongsToMany::make('videos'),
]),
```

This relatonship aggregates the results from each of its sub-relations, with the value returned in either the `data` member of its relationship field, or in a relationship endpoint.

The field is writeable as long as:

1. every sub-relationship is writeable (implements `FillableToMany`); and
2. each resource type that can be in the relationships maps to a single sub-relation.

Include paths also work, with the include paths only being applied to the sub-relations for which the include path is valid.