### PR TITLE
[Refactor] Scope filter static constructor fix

### DIFF
--- a/src/Filters/Scope.php
+++ b/src/Filters/Scope.php
@@ -43,11 +43,11 @@ class Scope implements Filter
      *
      * @param string $name
      * @param string|null $scope
-     * @return Scope
+     * @return static
      */
     public static function make(string $name, string $scope = null)
     {
-        return new self($name, $scope);
+        return new static($name, $scope);
     }
 
     /**


### PR DESCRIPTION
Changed `new self` to `new static`, like in other filters, to make it easier to inherit from that filter.