### PR TITLE
Relationship field filters

### DIFF
--- a/src/Filters/Concerns/Having.php
+++ b/src/Filters/Concerns/Having.php
@@ -1,0 +1,89 @@
+<?php
+/*
+ * Copyright 2021 Cloud Creativity Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+declare(strict_types=1);
+
+namespace LaravelJsonApi\Eloquent\Filters\Concerns;
+
+use LaravelJsonApi\Contracts\Schema\Schema;
+
+trait Having
+{
+    /**
+     * @var Schema
+     */
+    private Schema $schema;
+
+    /**
+     * @var string
+     */
+    private string $fieldName;
+
+    /**
+     * @var string
+     */
+    private string|null $key;
+
+    /**
+     * Create a new filter.
+     *
+     * @param Schema $schema
+     * @param string|null $fieldName
+     * @param string|null $key
+     * @return WhereHas
+     */
+    public static function make(Schema $schema, string $fieldName = null, string $key = null): self
+    {
+        return new static($schema, $fieldName, $key);
+    }
+
+    /**
+     * WhereDoesntHave constructor.
+     *
+     * @param Schema $schema
+     * @param string|null $fieldName
+     * @param string|null $key
+     */
+    public function __construct(Schema $schema, string $fieldName, string|null $key)
+    {
+        $this->schema = $schema;
+        $this->fieldName = $fieldName;
+        $this->key = $key;
+
+        if (! $this->schema->isRelationship($fieldName)) {
+            throw new \LogicException("Relationship with name $fieldName not defined in ". get_class($schema)." schema.");
+        }
+    }
+
+    /**
+     * Get the key for the filter.
+     *
+     * @return string
+     */
+    public function key(): string
+    {
+        return $this->key ?? $this->fieldName;
+    }
+
+    /**
+     * @return string
+     */
+    protected function relationName(): string
+    {
+        return $this->schema->relationship($this->fieldName)->relationName();
+    }
+}

--- a/src/Filters/Has.php
+++ b/src/Filters/Has.php
@@ -1,0 +1,56 @@
+<?php
+/*
+ * Copyright 2021 Cloud Creativity Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+declare(strict_types=1);
+
+namespace LaravelJsonApi\Eloquent\Filters;
+
+use LaravelJsonApi\Eloquent\Contracts\Filter;
+use LaravelJsonApi\Eloquent\Filters\Concerns\IsSingular;
+
+class Has implements Filter
+{
+    use IsSingular;
+    use Having;
+
+    /**
+     * Apply the filter to the query.
+     *
+     * @param \Illuminate\Database\Eloquent\Builder $query
+     * @param mixed $value
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    public function apply($query, $value)
+    {
+        $deserializedBoolean = (bool) $this->deserialize($value);
+
+        if ($deserializedBoolean === true) {
+            return $query->has($this->relationName());
+        }
+
+        return $query->whereDoesntHave($this->relationName());
+    }
+
+    /**
+     * @param $value
+     * @return bool
+     */
+    protected function deserialize($value): bool
+    {
+        return filter_var($value, FILTER_VALIDATE_BOOL);
+    }
+}

--- a/src/Filters/WhereDoesntHave.php
+++ b/src/Filters/WhereDoesntHave.php
@@ -1,0 +1,59 @@
+<?php
+/*
+ * Copyright 2021 Cloud Creativity Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+declare(strict_types=1);
+
+namespace LaravelJsonApi\Eloquent\Filters;
+
+use LaravelJsonApi\Eloquent\Contracts\Filter;
+use LaravelJsonApi\Eloquent\Filters\Concerns\IsSingular;
+use LaravelJsonApi\Eloquent\Filters\Concerns\DeserializesValue;
+
+class WhereDoesntHave implements Filter
+{
+    use DeserializesValue;
+    use IsSingular;
+    use Having;
+
+    /**
+     * Apply the filter to the query.
+     *
+     * @param \Illuminate\Database\Eloquent\Builder $query
+     * @param mixed $value
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    public function apply($query, $value)
+    {
+        $deserializedValues = $this->deserialize($value);
+
+        $relation = $this->schema->relationship($this->relationName());
+
+        $availableFilters = collect($relation->schema()->filters())->merge($relation->filters());
+
+        $keyedFilters = collect($availableFilters)->keyBy(function ($filter) {
+            return $filter->key();
+        })->all();
+
+        return $query->whereDoesntHave($this->relationName(), function ($query) use ($deserializedValues, $keyedFilters) {
+            foreach ($deserializedValues as $key => $value) {
+                if (isset($keyedFilters[$key])) {
+                    $keyedFilters[$key]->apply($query, $value);
+                }
+            }
+        });
+    }
+}

--- a/src/Filters/WhereHas.php
+++ b/src/Filters/WhereHas.php
@@ -1,0 +1,59 @@
+<?php
+/*
+ * Copyright 2021 Cloud Creativity Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+declare(strict_types=1);
+
+namespace LaravelJsonApi\Eloquent\Filters;
+
+use LaravelJsonApi\Eloquent\Contracts\Filter;
+use LaravelJsonApi\Eloquent\Filters\Concerns\IsSingular;
+use LaravelJsonApi\Eloquent\Filters\Concerns\DeserializesValue;
+
+class WhereHas implements Filter
+{
+    use DeserializesValue;
+    use IsSingular;
+    use Having;
+
+    /**
+     * Apply the filter to the query.
+     *
+     * @param \Illuminate\Database\Eloquent\Builder $query
+     * @param mixed $value
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    public function apply($query, $value)
+    {
+        $deserializedValues = $this->deserialize($value);
+
+        $relation = $this->schema->relationship($this->relationName());
+
+        $availableFilters = collect($relation->schema()->filters())->merge($relation->filters());
+
+        $keyedFilters = collect($availableFilters)->keyBy(function ($filter) {
+            return $filter->key();
+        })->all();
+
+        return $query->whereHas($this->relationName(), function ($query) use ($deserializedValues, $keyedFilters) {
+            foreach ($deserializedValues as $key => $value) {
+                if (isset($keyedFilters[$key])) {
+                    $keyedFilters[$key]->apply($query, $value);
+                }
+            }
+        });
+    }
+}


### PR DESCRIPTION
This PR adds the following filters: Has, WhereHas, and WhereDoesntHave.

### TLDR
Code taken from https://github.com/laravel-json-api/eloquent/pull/11. Made the requested changes. I'm not sure if tests are necessary as I don't see any other filter tests. After this PR is accepted, close https://github.com/laravel-json-api/eloquent/pull/11

### Usage
```php
use App\Model\Post;
use LaravelJsonApi\Eloquent\Filters\WhereHas;
use LaravelJsonApi\Eloquent\Fields\Relations\HasOne;

class PostSchema extends Schema
{
    /**
     * The model the schema corresponds to.
     *
     * @var string
     */
    public static string $model = Post::class;

    /**
     * Get the resource fields.
     *
     * @return array
     */
    public function fields(): array
    {
        return [
            ...
            HasOne::make('author'),
        ];
    }

    /**
     * Get the resource filters.
     *
     * @return array
     */
    public function filters(): array
    {
        return [
            ...
            WhereHas::make($this, 'author'),
        ];
    }
}
```
```php
use App\Model\Authors;
use LaravelJsonApi\Eloquent\Filters\Where;

class AuthorSchema extends Schema
{

    /**
     * The model the schema corresponds to.
     *
     * @var string
     */
    public static string $model = Authors::class;

    /**
     * Get the resource fields.
     *
     * @return array
     */
    public function fields(): array
    {
        return [
            ...
        ];
    }

    /**
     * Get the resource filters.
     *
     * @return array
     */
    public function filters(): array
    {
        return [
            ...
            Where::make('status'),
        ];
    }
}
```
```
GET /api/v1/posts?filter[authors][status]=active
```