### PR TITLE
Enable reading of filter configuration publicly

### DIFF
--- a/src/Filters/Concerns/HasColumn.php
+++ b/src/Filters/Concerns/HasColumn.php
@@ -1,0 +1,21 @@
+<?php
+
+
+namespace LaravelJsonApi\Eloquent\Filters\Concerns;
+
+
+trait HasColumn {
+
+    /**
+     * @var string
+     */
+    private string $column;
+
+    /**
+     * @return string
+     */
+    public function column(): string
+    {
+        return $this->column;
+    }
+}

--- a/src/Filters/Concerns/HasOperator.php
+++ b/src/Filters/Concerns/HasOperator.php
@@ -1,0 +1,73 @@
+<?php
+
+
+namespace LaravelJsonApi\Eloquent\Filters\Concerns;
+
+trait HasOperator {
+
+    /**
+     * @var string
+     */
+    private string $operator;
+
+    /**
+     * @return $this
+     */
+    public function eq(): self
+    {
+        return $this->using('=');
+    }
+
+    /**
+     * @return $this
+     */
+    public function gt(): self
+    {
+        return $this->using('>');
+    }
+
+    /**
+     * @return $this
+     */
+    public function gte(): self
+    {
+        return $this->using('>=');
+    }
+
+    /**
+     * @return $this
+     */
+    public function lt(): self
+    {
+        return $this->using('<');
+    }
+
+    /**
+     * @return $this
+     */
+    public function lte(): self
+    {
+        return $this->using('<=');
+    }
+
+    /**
+     * Use the provided operator for the filter.
+     *
+     * @param string $operator
+     * @return $this
+     */
+    public function using(string $operator): self
+    {
+        $this->operator = $operator;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function operator(): string
+    {
+        return $this->operator;
+    }
+}

--- a/src/Filters/Where.php
+++ b/src/Filters/Where.php
@@ -26,22 +26,14 @@ class Where implements Filter
 {
 
     use Concerns\DeserializesValue;
+    use Concerns\HasColumn;
+    use Concerns\HasOperator;
     use Concerns\IsSingular;
 
     /**
      * @var string
      */
     private string $name;
-
-    /**
-     * @var string
-     */
-    private string $column;
-
-    /**
-     * @var string
-     */
-    private string $operator;
 
     /**
      * Create a new filter.
@@ -69,59 +61,6 @@ class Where implements Filter
     }
 
     /**
-     * @return $this
-     */
-    public function eq(): self
-    {
-        return $this->using('=');
-    }
-
-    /**
-     * @return $this
-     */
-    public function gt(): self
-    {
-        return $this->using('>');
-    }
-
-    /**
-     * @return $this
-     */
-    public function gte(): self
-    {
-        return $this->using('>=');
-    }
-
-    /**
-     * @return $this
-     */
-    public function lt(): self
-    {
-        return $this->using('<');
-    }
-
-    /**
-     * @return $this
-     */
-    public function lte(): self
-    {
-        return $this->using('<=');
-    }
-
-    /**
-     * Use the provided operator for the filter.
-     *
-     * @param string $operator
-     * @return $this
-     */
-    public function using(string $operator): self
-    {
-        $this->operator = $operator;
-
-        return $this;
-    }
-
-    /**
      * @inheritDoc
      */
     public function key(): string
@@ -139,22 +78,6 @@ class Where implements Filter
             $this->operator(),
             $this->deserialize($value)
         );
-    }
-
-    /**
-     * @return string
-     */
-    protected function column(): string
-    {
-        return $this->column;
-    }
-
-    /**
-     * @return string
-     */
-    protected function operator(): string
-    {
-        return $this->operator;
     }
 
     /**

--- a/src/Filters/WhereIn.php
+++ b/src/Filters/WhereIn.php
@@ -26,17 +26,13 @@ class WhereIn implements Filter
 {
 
     use Concerns\DeserializesValue;
+    use Concerns\HasColumn;
     use Concerns\HasDelimiter;
 
     /**
      * @var string
      */
     private string $name;
-
-    /**
-     * @var string
-     */
-    private string $column;
 
     /**
      * Create a new filter.
@@ -87,14 +83,6 @@ class WhereIn implements Filter
             $query->getModel()->qualifyColumn($this->column()),
             $this->deserialize($value)
         );
-    }
-
-    /**
-     * @return string
-     */
-    protected function column(): string
-    {
-        return $this->column;
     }
 
     /**


### PR DESCRIPTION
Refactor filters to some traits enable checking for implemented trait and asking column and operator configuration.

Reason i used traits is so we can check if a trait is implemented with [Laravel method class_uses_recursive](https://laravel.com/docs/8.x/helpers#method-class-uses-recursive).

Fixes #17 