### PR TITLE
Fix wrong Boolean validation

### DIFF
--- a/src/Fields/Boolean.php
+++ b/src/Fields/Boolean.php
@@ -39,11 +39,16 @@ class Boolean extends Attribute
      */
     protected function assertValue($value): void
     {
-        if (!is_null($value) && !is_bool($value)) {
+        if (!is_null($value) && is_null($this->is_boolean($value))) {
             throw new \UnexpectedValueException(sprintf(
                 'Expecting the value of attribute %s to be a boolean.',
                 $this->name()
             ));
         }
     }
+
+	protected function is_boolean($value)
+	{
+		return filter_var($value, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);
+	}
 }


### PR DESCRIPTION
is_bool() consider 1 and 0 are not booleans. Eloquent may store a boolean like 1 or 0 in database, so if value is 1 or 0 it's considered as a boolean.

This PR fixes a validation error when updating a resource with laravel-json-api. If you have an attribute which is Boolean in resource Schema and don't provide a value when updating the resource, old value will be value retrieved from database (So may be 1 or 0) and it would say provided value is not a bool (Since is_bool() php function consider those values as false).