### PR TITLE
Add support for custom too many relations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file. This project adheres to
 [Semantic Versioning](http://semver.org/) and [this changelog format](http://keepachangelog.com/).
 
+## Unreleased
+
+### Added
+
+- [#30](https://github.com/laravel-json-api/eloquent/pull/30) Allow a wider range of Eloquent relations in
+  the `QueryToMany` and `QueryToOne` classes. This means packages
+  like [culturegr/custom-relation](https://github.com/culturegr/custom-relation) will work with this package.
+
 ## [3.0.1] - 2023-04-03
 
 ### Fixed

--- a/src/QueryToMany.php
+++ b/src/QueryToMany.php
@@ -170,18 +170,10 @@ class QueryToMany implements QueryManyBuilder, HasPagination
         if ($relation instanceof EloquentHasMany ||
             $relation instanceof EloquentBelongsToMany ||
             $relation instanceof EloquentHasManyThrough ||
-            $relation instanceof EloquentMorphMany
+            $relation instanceof EloquentMorphMany ||
+            $relation instanceof EloquentRelation
         ) {
             return $relation;
-        }
-
-        if ($relation instanceof EloquentRelation) {
-            throw new LogicException(sprintf(
-                'Eloquent relation %s on model %s returned a %s relation, which is not a to-many relation.',
-                $name,
-                get_class($this->model),
-                get_class($relation)
-            ));
         }
 
         throw new LogicException(sprintf(

--- a/src/QueryToMany.php
+++ b/src/QueryToMany.php
@@ -167,13 +167,12 @@ class QueryToMany implements QueryManyBuilder, HasPagination
         $name = $this->relation->relationName();
         $relation = $this->model->{$name}();
 
-        if ($relation instanceof EloquentHasMany ||
-            $relation instanceof EloquentBelongsToMany ||
-            $relation instanceof EloquentHasManyThrough ||
-            $relation instanceof EloquentMorphMany ||
-            $relation instanceof EloquentRelation
+        if (!$relation instanceof EloquentHasOne &&
+            !$relation instanceof EloquentBelongsTo &&
+            !$relation instanceof EloquentHasOneThrough &&
+            !$relation instanceof EloquentMorphOne
         ) {
-            return $relation;
+            if ($relation instanceof EloquentRelation) return $relation;
         }
 
         throw new LogicException(sprintf(

--- a/src/QueryToOne.php
+++ b/src/QueryToOne.php
@@ -105,9 +105,9 @@ class QueryToOne implements QueryOneBuilder
         $name = $this->relation->relationName();
         $relation = $this->model->{$name}();
 
-        if (!$relation instanceof EloquentHasMany ||
-            !$relation instanceof EloquentBelongsToMany ||
-            !$relation instanceof EloquentHasManyThrough ||
+        if (!$relation instanceof EloquentHasMany &&
+            !$relation instanceof EloquentBelongsToMany &&
+            !$relation instanceof EloquentHasManyThrough &&
             !$relation instanceof EloquentMorphMany
 
         ) {

--- a/src/QueryToOne.php
+++ b/src/QueryToOne.php
@@ -20,17 +20,12 @@ declare(strict_types=1);
 namespace LaravelJsonApi\Eloquent;
 
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Relations\BelongsTo as EloquentBelongsTo;
-use Illuminate\Database\Eloquent\Relations\HasOne as EloquentHasOne;
-use Illuminate\Database\Eloquent\Relations\HasOneThrough as EloquentHasOneThrough;
-use Illuminate\Database\Eloquent\Relations\MorphOne as EloquentMorphOne;
 use Illuminate\Database\Eloquent\Relations\Relation as EloquentRelation;
 use LaravelJsonApi\Contracts\Store\QueryOneBuilder;
 use LaravelJsonApi\Contracts\Store\QueryOneBuilder as QueryOneBuilderContract;
 use LaravelJsonApi\Core\Query\Custom\ExtendedQueryParameters;
 use LaravelJsonApi\Eloquent\Fields\Relations\ToOne;
 use LaravelJsonApi\Eloquent\QueryBuilder\JsonApiBuilder;
-use LogicException;
 use function sprintf;
 
 class QueryToOne implements QueryOneBuilder
@@ -103,22 +98,22 @@ class QueryToOne implements QueryOneBuilder
     private function getRelation(): EloquentRelation
     {
         $name = $this->relation->relationName();
+
+        assert(method_exists($this->model, $name), sprintf(
+            'Expecting method %s to exist on model %s',
+            $name,
+            $this->model::class,
+        ));
+
         $relation = $this->model->{$name}();
 
-        if (!$relation instanceof EloquentHasMany &&
-            !$relation instanceof EloquentBelongsToMany &&
-            !$relation instanceof EloquentHasManyThrough &&
-            !$relation instanceof EloquentMorphMany
-
-        ) {
-            if ($relation instanceof EloquentRelation) return $relation;
-        }
-
-        throw new LogicException(sprintf(
+        assert($relation instanceof EloquentRelation, sprintf(
             'Expecting method %s on model %s to return an Eloquent relation.',
             $name,
-            get_class($this->model)
+            $this->model::class,
         ));
+
+        return $relation;
     }
 
     /**

--- a/src/QueryToOne.php
+++ b/src/QueryToOne.php
@@ -105,21 +105,13 @@ class QueryToOne implements QueryOneBuilder
         $name = $this->relation->relationName();
         $relation = $this->model->{$name}();
 
-        if ($relation instanceof EloquentHasOne ||
-            $relation instanceof EloquentBelongsTo ||
-            $relation instanceof EloquentHasOneThrough ||
-            $relation instanceof EloquentMorphOne
-        ) {
-            return $relation;
-        }
+        if (!$relation instanceof EloquentHasMany ||
+            !$relation instanceof EloquentBelongsToMany ||
+            !$relation instanceof EloquentHasManyThrough ||
+            !$relation instanceof EloquentMorphMany
 
-        if ($relation instanceof EloquentRelation) {
-            throw new LogicException(sprintf(
-                'Eloquent relation %s on model %s returned a %s relation, which is not a to-one relation.',
-                $name,
-                get_class($this->model),
-                get_class($relation)
-            ));
+        ) {
+            if ($relation instanceof EloquentRelation) return $relation;
         }
 
         throw new LogicException(sprintf(


### PR DESCRIPTION
We need support for custom relations like https://github.com/culturegr/custom-relation. However Laravel JSONAPI is restricted to the default types (HasMany, etc). This simple change allows our needed custom 'too many' relation to work in Laravel JSONAPI and does not seem to have any side effects. We hope it can be integrated or an alternative added so that we can continue using the library.