### PR TITLE
added the ability to use resolveRelationUsing and still use the package

### DIFF
--- a/src/Fields/Relations/BelongsTo.php
+++ b/src/Fields/Relations/BelongsTo.php
@@ -58,7 +58,7 @@ class BelongsTo extends ToOne implements FillableToOne
     {
         $name = $this->relationName();
 
-        assert(method_exists($model, $name), sprintf(
+        assert(method_exists($model, $name)  || $model->relationResolver($model::class, $name), sprintf(
             'Expecting method %s to exist on model %s.',
             $name,
             $model::class,

--- a/src/Fields/Relations/BelongsToMany.php
+++ b/src/Fields/Relations/BelongsToMany.php
@@ -150,7 +150,7 @@ class BelongsToMany extends ToMany implements FillableToMany
     {
         $name = $this->relationName();
 
-        assert(method_exists($model, $name), sprintf(
+        assert(method_exists($model, $name) || $model->relationResolver($model::class, $name), sprintf(
             'Expecting method %s to exist on model %s.',
             $name,
             $model::class,

--- a/src/Fields/Relations/HasMany.php
+++ b/src/Fields/Relations/HasMany.php
@@ -159,7 +159,7 @@ class HasMany extends ToMany implements FillableToMany
     {
         $name = $this->relationName();
 
-        assert(method_exists($model, $name), sprintf(
+        assert(method_exists($model, $name) || $model->relationResolver($model::class, $name), sprintf(
             'Expecting method %s to exist on model %s.',
             $name,
             $model::class,

--- a/src/Fields/Relations/HasOne.php
+++ b/src/Fields/Relations/HasOne.php
@@ -100,7 +100,7 @@ class HasOne extends ToOne implements FillableToOne
     {
         $name = $this->relationName();
 
-        assert(method_exists($model, $name), sprintf(
+        assert(method_exists($model, $name) || $model->relationResolver($model::class, $name), sprintf(
             'Expecting method %s to exist on model %s.',
             $name,
             $model::class,

--- a/src/QueryToMany.php
+++ b/src/QueryToMany.php
@@ -152,7 +152,7 @@ class QueryToMany implements QueryManyBuilder, HasPagination
     {
         $name = $this->relation->relationName();
 
-        assert(method_exists($this->model, $name), sprintf(
+        assert(method_exists($this->model, $name)  || $this->model->relationResolver($this->model::class, $name), sprintf(
             'Expecting method %s to exist on model %s',
             $name,
             $this->model::class,

--- a/src/QueryToOne.php
+++ b/src/QueryToOne.php
@@ -90,7 +90,7 @@ class QueryToOne implements QueryOneBuilder
     {
         $name = $this->relation->relationName();
 
-        assert(method_exists($this->model, $name), sprintf(
+        assert(method_exists($this->model, $name)  || $this->model->relationResolver($this->model::class, $name), sprintf(
             'Expecting method %s to exist on model %s',
             $name,
             $this->model::class,


### PR DESCRIPTION
If you add a relation to a model via the Model::resolveRelationUsing() method (https://laravel.com/docs/11.x/eloquent-relationships#dynamic-relationships) the getRelation() methods in QueryToMany, QueryToOne, HasMany, HasOne, BelongsTo and BelongsToMany don't recognize it as they use method_exists to check if it's available, whereas the relations created this way are only available to the instance and when checked with relationResolver.

Added the checks with relationResolver to all the relevant places