### PR TITLE
feat: add eloquent cursor pagination implementation

### DIFF
--- a/src/Pagination/Cursor/Cursor.php
+++ b/src/Pagination/Cursor/Cursor.php
@@ -1,0 +1,116 @@
+<?php
+/*
+ * Copyright 2023 Cloud Creativity Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+declare(strict_types=1);
+
+namespace LaravelJsonApi\Eloquent\Pagination\Cursor;
+
+use InvalidArgumentException;
+
+class Cursor
+{
+
+    /**
+     * @var string|null
+     */
+    private ?string $before;
+
+    /**
+     * @var string|null
+     */
+    private ?string $after;
+
+    /**
+     * @var int|null
+     */
+    private ?int $limit;
+
+    /**
+     * Cursor constructor.
+     *
+     * @param string|null $before
+     * @param string|null $after
+     * @param int|null $limit
+     */
+    public function __construct(string $before = null, string $after = null, int $limit = null)
+    {
+        if (is_int($limit) && 1 > $limit) {
+            throw new InvalidArgumentException('Expecting a limit that is 1 or greater.');
+        }
+
+        $this->before = $before ?: null;
+        $this->after = $after ?: null;
+        $this->limit = $limit;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isBefore(): bool
+    {
+        return !is_null($this->before);
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getBefore(): ?string
+    {
+        return $this->before;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isAfter(): bool
+    {
+        return !is_null($this->after) && !$this->isBefore();
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getAfter(): ?string
+    {
+        return $this->after;
+    }
+
+    /**
+     * Set a limit, if no limit is set on the cursor.
+     *
+     * @param int $limit
+     * @return Cursor
+     */
+    public function withDefaultLimit(int $limit): self
+    {
+        if (is_null($this->limit)) {
+            $copy = clone $this;
+            $copy->limit = $limit;
+            return $copy;
+        }
+
+        return $this;
+    }
+
+    /**
+     * @return int|null
+     */
+    public function getLimit(): ?int
+    {
+        return $this->limit;
+    }
+}

--- a/src/Pagination/Cursor/CursorBuilder.php
+++ b/src/Pagination/Cursor/CursorBuilder.php
@@ -1,0 +1,178 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaravelJsonApi\Eloquent\Pagination\Cursor;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Relations\Relation;
+use Illuminate\Pagination\Cursor as LaravelCursor;
+use LaravelJsonApi\Contracts\Schema\ID;
+use LaravelJsonApi\Core\Schema\IdParser;
+
+class CursorBuilder
+{
+    private Builder|Relation $query;
+
+    private ?ID $id = null;
+
+    private string $keyName;
+
+    private string $direction;
+
+    private ?int $defaultPerPage = null;
+
+    private bool $withTotal;
+
+    private bool $keySort = true;
+
+    /**
+     * CursorBuilder constructor.
+     *
+     * @param Builder|Relation $query
+     *      the column to use for the cursor
+     * @param string|null $key
+     *      the key column that the before/after cursors related to
+     */
+    public function __construct($query, string $key = null)
+    {
+        if (!$query instanceof Builder && !$query instanceof Relation) {
+            throw new \InvalidArgumentException('Expecting an Eloquent query builder or relation.');
+        }
+
+        $this->query = $query;
+        $this->keyName = $key ?: $this->guessKey();
+    }
+
+    /**
+     * Set the default number of items per-page.
+     *
+     * If null, the default from the `Model::getPage()` method will be used.
+     *
+     * @return $this
+     */
+    public function withDefaultPerPage(?int $perPage): self
+    {
+        $this->defaultPerPage = $perPage;
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
+    public function withIdField(?ID $id): self
+    {
+        $this->id = $id;
+
+        return $this;
+    }
+
+    public function withKeySort(bool $keySort): self
+    {
+        $this->keySort = $keySort;
+
+        return $this;
+    }
+
+    /**
+     * Set the query direction.
+     *
+     * @return $this
+     */
+    public function withDirection(string $direction): self
+    {
+        if (\in_array($direction, ['asc', 'desc'])) {
+            $this->direction = $direction;
+
+            return $this;
+        }
+
+        throw new \InvalidArgumentException('Unexpected query direction.');
+    }
+
+    public function withTotal(bool $withTotal): self
+    {
+        $this->withTotal = $withTotal;
+
+        return $this;
+    }
+
+    /**
+     * @param array<string> $columns
+     */
+    public function paginate(Cursor $cursor, array $columns = ['*']): CursorPaginator
+    {
+        $cursor = $cursor->withDefaultLimit($this->getDefaultPerPage());
+
+        $this->applyKeySort();
+
+        $total = $this->getTotal();
+        $laravelPaginator = $this->query->cursorPaginate($cursor->getLimit(), $columns, 'cursor', $this->convertCursor($cursor));
+        $paginator = new CursorPaginator($laravelPaginator, $cursor, $total);
+
+        return $paginator->withCurrentPath();
+    }
+
+    private function applyKeySort(): void
+    {
+        if (!$this->keySort) {
+            return;
+        }
+
+        if (
+            empty($this->query->getQuery()->orders)
+            || collect($this->query->getQuery()->orders)
+                ->whereIn('column', [$this->keyName, $this->query->qualifyColumn($this->keyName)])
+                ->isEmpty()
+        ) {
+            $this->query->orderBy($this->keyName, $this->direction);
+        }
+    }
+
+    private function getTotal(): ?int
+    {
+        return $this->withTotal ? $this->query->count() : null;
+    }
+
+    private function convertCursor(Cursor $cursor): ?LaravelCursor
+    {
+        $encodedCursor = $cursor->isBefore() ? $cursor->getBefore() : $cursor->getAfter();
+        if (!is_string($encodedCursor)) {
+            return null;
+        }
+
+        $parameters = json_decode(base64_decode(str_replace(['-', '_'], ['+', '/'], $encodedCursor)), true);
+
+        if (json_last_error() !== JSON_ERROR_NONE) {
+            return null;
+        }
+
+        $pointsToNextItems = $parameters['_pointsToNextItems'];
+        unset($parameters['_pointsToNextItems']);
+        if (isset($parameters[$this->keyName])) {
+            $parameters[$this->keyName] = IdParser::make($this->id)->decode(
+                (string) $parameters[$this->keyName],
+            );
+        }
+
+        return new LaravelCursor($parameters, $pointsToNextItems);
+    }
+
+    private function getDefaultPerPage(): int
+    {
+        if (is_int($this->defaultPerPage)) {
+            return $this->defaultPerPage;
+        }
+
+        return $this->query->getModel()->getPerPage();
+    }
+
+    /**
+     * Guess the key to use for the cursor.
+     */
+    private function guessKey(): string
+    {
+        return $this->id?->key() ?? $this->query->getModel()->getKeyName();
+    }
+}

--- a/src/Pagination/Cursor/CursorPage.php
+++ b/src/Pagination/Cursor/CursorPage.php
@@ -1,0 +1,171 @@
+<?php
+/*
+ * Copyright 2023 Cloud Creativity Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+declare(strict_types=1);
+
+namespace LaravelJsonApi\Eloquent\Pagination\Cursor;
+
+use LaravelJsonApi\Core\Document\Link;
+use LaravelJsonApi\Core\Pagination\AbstractPage;
+
+class CursorPage extends AbstractPage
+{
+    private CursorPaginator $paginator;
+
+    private string $before;
+
+    private string $after;
+
+    private string $limit;
+
+    /**
+     * CursorPage constructor.
+     */
+    public function __construct(CursorPaginator $paginator)
+    {
+        $this->paginator = $paginator;
+    }
+
+    /**
+     * Fluent constructor.
+     */
+    public static function make(CursorPaginator $paginator): self
+    {
+        return new self($paginator);
+    }
+
+    /**
+     * Set the "after" parameter.
+     *
+     * @return $this
+     */
+    public function withAfterParam(string $key): self
+    {
+        if (empty($key)) {
+            throw new \InvalidArgumentException('Expecting a non-empty string.');
+        }
+
+        $this->after = $key;
+
+        return $this;
+    }
+
+    /**
+     * Set the "before" parameter.
+     *
+     * @return $this
+     */
+    public function withBeforeParam(string $key): self
+    {
+        if (empty($key)) {
+            throw new \InvalidArgumentException('Expecting a non-empty string.');
+        }
+
+        $this->before = $key;
+
+        return $this;
+    }
+
+    /**
+     * Set the "limit" parameter.
+     *
+     * @return $this
+     */
+    public function withLimitParam(string $key): self
+    {
+        if (empty($key)) {
+            throw new \InvalidArgumentException('Expecting a non-empty string.');
+        }
+
+        $this->limit = $key;
+
+        return $this;
+    }
+
+    public function first(): ?Link
+    {
+        return new Link('first', $this->url([
+            $this->limit => $this->paginator->getPerPage(),
+        ]));
+    }
+
+    public function prev(): ?Link
+    {
+        if ($this->paginator->isNotEmpty() && $this->paginator->hasPrev()) {
+            return new Link('prev', $this->url([
+                $this->before => $this->paginator->firstItem(),
+                $this->limit => $this->paginator->getPerPage(),
+            ]));
+        }
+
+        return null;
+    }
+
+    public function next(): ?Link
+    {
+        if ($this->paginator->isNotEmpty() && $this->paginator->hasNext()) {
+            return new Link('next', $this->url([
+                $this->after => $this->paginator->lastItem(),
+                $this->limit => $this->paginator->getPerPage(),
+            ]));
+        }
+
+        return null;
+    }
+
+    public function last(): ?Link
+    {
+        return null;
+    }
+
+    /**
+     * @param array<string,mixed> $page
+     */
+    public function url(array $page): string
+    {
+        return $this->paginator->path() . '?' . $this->stringifyQuery($page);
+    }
+
+    public function getIterator(): \Traversable
+    {
+        yield from $this->paginator;
+    }
+
+    public function count(): int
+    {
+        return $this->paginator->count();
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    protected function metaForPage(): array
+    {
+        $meta = [
+            'perPage' => $this->paginator->getPerPage(),
+            'from' => $this->paginator->getFrom(),
+            'to' => $this->paginator->getTo(),
+            'hasMore' => $this->paginator->hasMorePages(),
+        ];
+        $total = $this->paginator->getTotal();
+        if ($total !== null) {
+            $meta['total'] = $total;
+        }
+
+        return $meta;
+    }
+}

--- a/src/Pagination/Cursor/CursorPaginator.php
+++ b/src/Pagination/Cursor/CursorPaginator.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaravelJsonApi\Eloquent\Pagination\Cursor;
+
+use Illuminate\Contracts\Pagination\CursorPaginator as LaravelCursorPaginator;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Pagination\Paginator;
+
+class CursorPaginator implements \IteratorAggregate, \Countable
+{
+    private Collection $items;
+
+    private ?string $path;
+
+    /**
+     * CursorPaginator constructor.
+     */
+    public function __construct(private readonly LaravelCursorPaginator $laravelPaginator, private readonly Cursor $cursor, private readonly int|null $total = null)
+    {
+        $this->items = Collection::make($this->laravelPaginator->items());
+    }
+
+    public function getItems(): Collection
+    {
+        return $this->items;
+    }
+
+    public function firstItem(): ?string
+    {
+
+        if ($this->laravelPaginator->isEmpty()) {
+            return null;
+        }
+
+        return $this->laravelPaginator->getCursorForItem($this->items->first(), false)->encode();
+    }
+
+    public function lastItem(): ?string
+    {
+        if ($this->laravelPaginator->isEmpty()) {
+            return null;
+        }
+
+        return $this->laravelPaginator->getCursorForItem($this->items->last())->encode();
+    }
+
+    public function hasMorePages(): bool
+    {
+        return ($this->cursor->isBefore() && !$this->laravelPaginator->onFirstPage()) || $this->laravelPaginator->hasMorePages();
+    }
+
+    public function hasNext()
+    {
+        return ((!$this->cursor->isAfter() && !$this->cursor->isBefore()) || $this->cursor->isAfter()) && $this->hasMorePages();
+    }
+
+    public function hasPrev()
+    {
+        return ($this->cursor->isBefore() && $this->hasMorePages()) || $this->cursor->isAfter();
+    }
+
+    public function hasNoMorePages(): bool
+    {
+        return !$this->hasMorePages();
+    }
+
+    public function getPerPage(): int
+    {
+        return $this->laravelPaginator->perPage();
+    }
+
+    public function getFrom(): ?string
+    {
+        return $this->firstItem();
+    }
+
+    public function getTo(): ?string
+    {
+        return $this->lastItem();
+    }
+
+    public function getTotal(): ?int
+    {
+        return $this->total;
+    }
+
+    public function getIterator(): \Traversable
+    {
+        yield from $this->items;
+    }
+
+    public function count(): int
+    {
+        return $this->items->count();
+    }
+
+    public function isEmpty(): bool
+    {
+        return $this->items->isEmpty();
+    }
+
+    public function isNotEmpty(): bool
+    {
+        return !$this->isEmpty();
+    }
+
+    public function withCurrentPath(): self
+    {
+        $this->path = Paginator::resolveCurrentPath();
+
+        return $this;
+    }
+
+    public function withPath(string $path): self
+    {
+        $this->path = $path;
+
+        return $this;
+    }
+
+    /**
+     * Get the base path for paginator generated URLs.
+     */
+    public function path(): ?string
+    {
+        return $this->path;
+    }
+}

--- a/src/Pagination/Cursor/CursorPaginator.php
+++ b/src/Pagination/Cursor/CursorPaginator.php
@@ -17,7 +17,7 @@ class CursorPaginator implements \IteratorAggregate, \Countable
     /**
      * CursorPaginator constructor.
      */
-    public function __construct(private readonly LaravelCursorPaginator $laravelPaginator, private readonly Cursor $cursor, private readonly int|null $total = null)
+    public function __construct(private readonly CursorParser $parser, private readonly LaravelCursorPaginator $laravelPaginator, private readonly Cursor $cursor, private readonly int|null $total = null)
     {
         $this->items = Collection::make($this->laravelPaginator->items());
     }
@@ -34,7 +34,7 @@ class CursorPaginator implements \IteratorAggregate, \Countable
             return null;
         }
 
-        return $this->laravelPaginator->getCursorForItem($this->items->first(), false)->encode();
+        return $this->parser->encode($this->laravelPaginator->getCursorForItem($this->items->first(), false));
     }
 
     public function lastItem(): ?string
@@ -43,7 +43,7 @@ class CursorPaginator implements \IteratorAggregate, \Countable
             return null;
         }
 
-        return $this->laravelPaginator->getCursorForItem($this->items->last())->encode();
+        return $this->parser->encode($this->laravelPaginator->getCursorForItem($this->items->last()));
     }
 
     public function hasMorePages(): bool

--- a/src/Pagination/Cursor/CursorParser.php
+++ b/src/Pagination/Cursor/CursorParser.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace LaravelJsonApi\Eloquent\Pagination\Cursor;
+
+use Illuminate\Pagination\Cursor as LaravelCursor;
+use LaravelJsonApi\Core\Schema\IdParser;
+
+class CursorParser
+{
+    public function __construct(private IdParser $idParser, private string $keyName)
+    {
+
+    }
+
+    public function encode(LaravelCursor $cursor): string
+    {
+        $key  = $cursor->parameter($this->keyName);
+        if (!$key) {
+            return $cursor->encode();
+        }
+
+        $encodedId = $this->idParser->encode($key);
+        $parameters = $cursor->toArray();
+        unset($parameters['_pointsToNextItems']);
+        $parameters[$this->keyName] = $encodedId;
+
+        $newCursor = new LaravelCursor($parameters, $cursor->pointsToNextItems());
+        return $newCursor->encode();
+    }
+
+    public function decode(Cursor $cursor): ?LaravelCursor
+    {
+        $encodedCursor = $cursor->isBefore() ? $cursor->getBefore() : $cursor->getAfter();
+        if (!is_string($encodedCursor)) {
+            return null;
+        }
+
+        $parameters = json_decode(base64_decode(str_replace(['-', '_'], ['+', '/'], $encodedCursor)), true);
+
+        if (json_last_error() !== JSON_ERROR_NONE) {
+            return null;
+        }
+
+        $pointsToNextItems = $parameters['_pointsToNextItems'];
+        unset($parameters['_pointsToNextItems']);
+        if (isset($parameters[$this->keyName])) {
+            $parameters[$this->keyName] = $this->idParser->decode(
+                $parameters[$this->keyName],
+            );
+        }
+
+        return new LaravelCursor($parameters, $pointsToNextItems);
+    }
+}

--- a/src/Pagination/CursorPagination.php
+++ b/src/Pagination/CursorPagination.php
@@ -1,0 +1,249 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaravelJsonApi\Eloquent\Pagination;
+
+use LaravelJsonApi\Eloquent\Pagination\Cursor\CursorBuilder;
+use LaravelJsonApi\Eloquent\Pagination\Cursor\CursorPage;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Relations\Relation;
+use LaravelJsonApi\Contracts\Pagination\Page;
+use LaravelJsonApi\Contracts\Schema\ID;
+use LaravelJsonApi\Core\Pagination\Concerns\HasPageMeta;
+use LaravelJsonApi\Eloquent\Pagination\Cursor\Cursor;
+use LaravelJsonApi\Eloquent\Contracts\Paginator;
+
+class CursorPagination implements Paginator
+{
+    use HasPageMeta;
+
+    private string $before;
+
+    private string $after;
+
+    private string $limit;
+
+    private string $direction;
+
+    private ?string $primaryKey = null;
+
+    /** @var string|array<string>|null */
+    private string|array|null $columns = null;
+
+    private ?int $defaultPerPage = null;
+
+    private bool $withTotal;
+
+    private bool $withTotalOnFirstPage;
+
+    private bool $keySort = true;
+
+    /**
+     * CursorPagination constructor.
+     */
+    public function __construct(private readonly ID $id)
+    {
+        $this->before = 'before';
+        $this->after = 'after';
+        $this->limit = 'limit';
+        $this->metaKey = 'page';
+        $this->direction = 'desc';
+        $this->withTotal = false;
+        $this->withTotalOnFirstPage = false;
+    }
+
+    /**
+     * Fluent constructor.
+     */
+    public static function make(ID $id): self
+    {
+        return new self($id);
+    }
+
+    /**
+     * Set the "after" key.
+     *
+     * @return $this
+     */
+    public function withAfterKey(string $key): self
+    {
+        if (empty($key)) {
+            throw new \InvalidArgumentException('Expecting a non-empty string.');
+        }
+
+        $this->after = $key;
+
+        return $this;
+    }
+
+    /**
+     * Set the "before" key.
+     *
+     * @return $this
+     */
+    public function withBeforeKey(string $key): self
+    {
+        if (empty($key)) {
+            throw new \InvalidArgumentException('Expecting a non-empty string.');
+        }
+
+        $this->before = $key;
+
+        return $this;
+    }
+
+    /**
+     * Set the "limit" key.
+     *
+     * @return $this
+     */
+    public function withLimitKey(string $key): self
+    {
+        if (empty($key)) {
+            throw new \InvalidArgumentException('Expecting a non-empty string.');
+        }
+
+        $this->limit = $key;
+
+        return $this;
+    }
+
+    /**
+     * Use an ascending order.
+     *
+     * @return $this
+     */
+    public function withAscending(): self
+    {
+        $this->direction = 'asc';
+
+        return $this;
+    }
+
+    /**
+     * Use the provided number as the default items per-page.
+     *
+     * If null, the default per-page set on the model class will be used.
+     *
+     * @return $this
+     */
+    public function withDefaultPerPage(?int $perPage): self
+    {
+        $this->defaultPerPage = $perPage;
+
+        return $this;
+    }
+
+    public function withTotal(bool $withTotal = true): self
+    {
+        $this->withTotal = $withTotal;
+
+        return $this;
+    }
+
+    public function withTotalOnFirstPage(bool $withTotal = true): self
+    {
+        $this->withTotalOnFirstPage = $withTotal;
+
+        return $this;
+    }
+
+    public function withKeyName(string $column): self
+    {
+        $this->primaryKey = $column;
+
+        return $this;
+    }
+
+    /**
+     * @param string|array<string> $columns
+     * @return $this
+     */
+    public function withColumns($columns): self
+    {
+        $this->columns = $columns;
+
+        return $this;
+    }
+
+    public function withKeySort(bool $keySort = true): self
+    {
+        $this->keySort = $keySort;
+
+        return $this;
+    }
+
+    public function withoutKeySort(): self
+    {
+        return $this->withKeySort(false);
+    }
+
+    /**
+     * @return array<string>
+     */
+    public function keys(): array
+    {
+        return [
+            $this->before,
+            $this->after,
+            $this->limit,
+        ];
+    }
+
+    /**
+     * @param Builder|Relation $query
+     * @param array<string, mixed> $page
+     */
+    public function paginate($query, array $page): Page
+    {
+        $cursor = $this->cursor($page);
+
+        $withTotal = $this->withTotal
+            || ($this->withTotalOnFirstPage
+            && !$cursor->isBefore()
+            && !$cursor->isAfter());
+
+        $paginator = $this
+            ->query($query)
+            ->withIdField($this->id)
+            ->withDirection($this->direction)
+            ->withKeySort($this->keySort)
+            ->withDefaultPerPage($this->defaultPerPage)
+            ->withTotal($withTotal)
+            ->paginate($cursor, $this->columns ?? ['*']);
+
+        return CursorPage::make($paginator)
+            ->withBeforeParam($this->before)
+            ->withAfterParam($this->after)
+            ->withLimitParam($this->limit)
+            ->withMeta($this->hasMeta)
+            ->withNestedMeta($this->metaKey)
+            ->withMetaCase($this->metaCase);
+    }
+
+    /**
+     * Create a new cursor query.
+     */
+    private function query(Builder|Relation $query): CursorBuilder
+    {
+        return new CursorBuilder($query, $this->primaryKey);
+    }
+
+    /**
+     * Extract the cursor from the provided paging parameters.
+     * @param array<string,mixed> $page
+     */
+    private function cursor(array $page): Cursor
+    {
+        $before = $page[$this->before] ?? null;
+        $after = $page[$this->after] ?? null;
+        $limit = $page[$this->limit] ?? null;
+
+        return new Cursor(
+            !is_null($before) ? strval($before) : null,
+            !is_null($after) ? strval($after) : null,
+            !is_null($limit) ? intval($limit) : null,
+        );
+    }
+}

--- a/src/Pagination/CursorPagination.php
+++ b/src/Pagination/CursorPagination.php
@@ -206,7 +206,6 @@ class CursorPagination implements Paginator
 
         $paginator = $this
             ->query($query)
-            ->withIdField($this->id)
             ->withDirection($this->direction)
             ->withKeySort($this->keySort)
             ->withDefaultPerPage($this->defaultPerPage)
@@ -227,7 +226,7 @@ class CursorPagination implements Paginator
      */
     private function query(Builder|Relation $query): CursorBuilder
     {
-        return new CursorBuilder($query, $this->primaryKey);
+        return new CursorBuilder($query, $this->id, $this->primaryKey);
     }
 
     /**

--- a/tests/app/Models/Video.php
+++ b/tests/app/Models/Video.php
@@ -52,7 +52,7 @@ class Video extends Model
     protected static function booting()
     {
         self::creating(static function (Video $video) {
-            $video->uuid = $video->uuid ?: Str::uuid()->toString();
+            $video->uuid = $video->uuid ?: Str::orderedUuid()->toString();
         });
     }
 

--- a/tests/app/Schemas/VideoSchema.php
+++ b/tests/app/Schemas/VideoSchema.php
@@ -45,7 +45,7 @@ class VideoSchema extends Schema
             BelongsToMany::make('tags')
                 ->fields(new ApprovedPivot())
                 ->canCount(),
-            Str::make('title'),
+            Str::make('title')->sortable(),
             DateTime::make('updatedAt')->sortable()->readOnly(),
             Str::make('url'),
         ];

--- a/tests/lib/Acceptance/Pagination/CursorPaginationTest.php
+++ b/tests/lib/Acceptance/Pagination/CursorPaginationTest.php
@@ -411,17 +411,14 @@ class CursorPaginationTest extends TestCase
         ]);
 
         $second = Video::factory()->create([
-            'uuid' => 'f3b3bea3-dca0-4ef9-b06c-43583a7e6118',
             'created_at' => Carbon::now()->subHour(),
         ]);
 
         $third = Video::factory()->create([
-            'uuid' => 'd215f35c-feb7-4cc5-9631-61742f00d0b2',
             'created_at' => $second->created_at,
         ]);
 
         $fourth = Video::factory()->create([
-            'uuid' => 'cbe17134-d7e2-4509-ba2c-3b3b5e3b2cbe',
             'created_at' => $second->created_at,
         ]);
 
@@ -429,13 +426,13 @@ class CursorPaginationTest extends TestCase
             ->sort('createdAt')
             ->paginate(['limit' => '3']);
 
-        $this->assertPage([$first, $second, $third], $page);
+        $this->assertPage([$first, $fourth, $third], $page);
 
         $page = $this->videos->repository()->queryAll()
             ->sort('-createdAt')
             ->paginate(['limit' => '3']);
 
-        $this->assertPage([$second, $third, $fourth], $page);
+        $this->assertPage([$fourth, $third, $second], $page);
     }
 
     public function testMultipleSorts(): void
@@ -447,19 +444,16 @@ class CursorPaginationTest extends TestCase
 
         $second = Video::factory()->create([
             'title' => 'a',
-            'uuid' => 'f3b3bea3-dca0-4ef9-b06c-43583a7e6118',
             'created_at' => Carbon::now()->subHour(),
         ]);
 
         $third = Video::factory()->create([
             'title' => 'b',
-            'uuid' => 'd215f35c-feb7-4cc5-9631-61742f00d0b2',
             'created_at' => $second->created_at,
         ]);
 
         $fourth = Video::factory()->create([
             'title' => 'a',
-            'uuid' => 'cbe17134-d7e2-4509-ba2c-3b3b5e3b2cbe',
             'created_at' => $second->created_at,
         ]);
 
@@ -467,13 +461,13 @@ class CursorPaginationTest extends TestCase
             ->sort('title,createdAt')
             ->paginate(['limit' => '3']);
 
-        $this->assertPage([$second, $fourth, $first], $page);
+        $this->assertPage([$fourth, $second, $first], $page);
 
         $page = $this->videos->repository()->queryAll()
             ->sort('title,-createdAt')
             ->paginate(['limit' => '3']);
 
-        $this->assertPage([$second, $fourth, $third], $page);
+        $this->assertPage([$fourth, $second, $third], $page);
     }
 
     public function testWithoutKeySort(): void
@@ -486,17 +480,14 @@ class CursorPaginationTest extends TestCase
 
         $second = Video::factory()->create([
             'title' => 'a',
-            'uuid' => 'f3b3bea3-dca0-4ef9-b06c-43583a7e6118',
         ]);
 
         $third = Video::factory()->create([
             'title' => 'c',
-            'uuid' => 'd215f35c-feb7-4cc5-9631-61742f00d0b2',
         ]);
 
         $fourth = Video::factory()->create([
             'title' => 'b',
-            'uuid' => 'cbe17134-d7e2-4509-ba2c-3b3b5e3b2cbe',
         ]);
 
         $page = $this->videos->repository()->queryAll()

--- a/tests/lib/Acceptance/Pagination/CursorPaginationTest.php
+++ b/tests/lib/Acceptance/Pagination/CursorPaginationTest.php
@@ -1,0 +1,765 @@
+<?php
+/*
+ * Copyright 2024 Cloud Creativity Limited
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE file or at
+ * https://opensource.org/licenses/MIT.
+ */
+
+declare(strict_types=1);
+
+namespace LaravelJsonApi\Eloquent\Tests\Acceptance\Pagination;
+
+use App\Models\Post;
+use App\Models\Video;
+use App\Schemas\PostSchema;
+use App\Schemas\VideoSchema;
+use Carbon\Carbon;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Pagination\AbstractPaginator;
+use Illuminate\Support\LazyCollection;
+use LaravelJsonApi\Contracts\Pagination\Page;
+use LaravelJsonApi\Core\Query\QueryParameters;
+use LaravelJsonApi\Core\Support\Arr;
+use LaravelJsonApi\Eloquent\Fields\ID;
+use LaravelJsonApi\Eloquent\Pagination\CursorPagination;
+use LaravelJsonApi\Eloquent\Tests\Acceptance\TestCase;
+use PHPUnit\Framework\MockObject\MockObject;
+
+class CursorPaginationTest extends TestCase
+{
+
+    /**
+     * @var CursorPagination
+     */
+    private CursorPagination $paginator;
+
+    /**
+     * @var PostSchema|MockObject
+     */
+    private PostSchema $posts;
+
+    /**
+     * @var VideoSchema|MockObject
+     */
+    private VideoSchema $videos;
+
+    /**
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->paginator = CursorPagination::make(ID::make()->uuid());
+
+        $this->posts = $this
+            ->getMockBuilder(PostSchema::class)
+            ->onlyMethods(['pagination', 'defaultPagination'])
+            ->setConstructorArgs(['server' => $this->server()])
+            ->getMock();
+
+        $this->videos = $this
+            ->getMockBuilder(VideoSchema::class)
+            ->onlyMethods(['pagination', 'defaultPagination'])
+            ->setConstructorArgs(['server' => $this->server()])
+            ->getMock();
+
+        $this->posts->method('pagination')->willReturn($this->paginator);
+        $this->videos->method('pagination')->willReturn($this->paginator);
+
+        $this->app->instance(PostSchema::class, $this->posts);
+        $this->app->instance(VideoSchema::class, $this->videos);
+
+        AbstractPaginator::currentPathResolver(fn() => url('/api/v1/posts'));
+    }
+
+    /**
+     * An schema's default pagination is used if no pagination parameters are sent.
+     *
+     * @see https://github.com/cloudcreativity/laravel-json-api/issues/131
+     */
+    public function testDefaultPagination(): void
+    {
+        $this->posts->method('defaultPagination')->willReturn(['limit' => 10]);
+
+        $meta = [
+            'from' => 'eyJpZCI6NCwiX3BvaW50c1RvTmV4dEl0ZW1zIjpmYWxzZX0',
+            'hasMore' => false,
+            'perPage' => 10,
+            'to' => 'eyJpZCI6MSwiX3BvaW50c1RvTmV4dEl0ZW1zIjp0cnVlfQ',
+        ];
+
+        $links = [
+
+            'first' => [
+                'href' => 'http://localhost/api/v1/posts?' . Arr::query([
+                        'page' => ['limit' => '10']
+                    ]),
+            ]
+        ];
+
+        $posts = Post::factory()->count(4)->create();
+
+        $page = $this->posts
+            ->repository()
+            ->queryAll()
+            ->firstOrPaginate(null);
+
+        $this->assertInstanceOf(Page::class, $page);
+        $this->assertSame(['page' => $meta], $page->meta());
+        $this->assertSame($links, $page->links()->toArray());
+        $this->assertPage($posts->reverse(), $page);
+    }
+
+    public function testNoDefaultPagination(): void
+    {
+        $this->posts->method('defaultPagination')->willReturn(null);
+
+        $posts = Post::factory()->count(4)->create();
+
+        $actual = $this->posts
+            ->repository()
+            ->queryAll()
+            ->firstOrPaginate(null);
+
+        $this->assertInstanceOf(LazyCollection::class, $actual);
+        $this->assertPage($posts, $actual);
+    }
+
+    /**
+     * If the schema has default pagination, but the client has used
+     * a singular filter AND not provided paging parameters, we
+     * expect the singular filter to be respected I.e. the default
+     * pagination must be ignored.
+     */
+    public function testDefaultPaginationWithSingularFilter(): void
+    {
+        $this->posts->method('defaultPagination')->willReturn(['limit' => 1]);
+
+        $posts = Post::factory()->count(4)->create();
+        $post = $posts[2];
+
+        $actual = $this->posts
+            ->repository()
+            ->queryAll()
+            ->filter(['slug' => $post->slug])
+            ->firstOrPaginate(null);
+
+        $this->assertInstanceOf(Post::class, $actual);
+        $this->assertTrue($post->is($actual));
+    }
+
+    /**
+     * Same as previous test but the filter does not match any models.
+     */
+    public function testDefaultPaginationWithSingularFilterThatDoesNotMatch(): void
+    {
+        $this->posts->method('defaultPagination')->willReturn(['limit' => 1]);
+
+        $post = Post::factory()->make();
+
+        $actual = $this->posts
+            ->repository()
+            ->queryAll()
+            ->filter(['slug' => $post->slug])
+            ->firstOrPaginate(null);
+
+        $this->assertNull($actual);
+    }
+
+    /**
+     * If the client uses a singular filter, but provides page parameters,
+     * they should get a page - not a zero-to-one response.
+     */
+    public function testPaginationWithSingularFilter(): void
+    {
+        $posts = Post::factory()->count(4)->create();
+        $post = $posts[2];
+
+        $actual = $this->posts
+            ->repository()
+            ->queryAll()
+            ->filter(['slug' => $post->slug])
+            ->firstOrPaginate(['number' => '1']);
+
+        $this->assertInstanceOf(Page::class, $actual);
+        $this->assertPage([$post], $actual);
+    }
+
+    /**
+     * If the search does not match any models, then there are no pages.
+     */
+    public function testNoPages(): void
+    {
+        $meta = [
+            'from' => null,
+            'hasMore' => false,
+            'perPage' => 3,
+            'to' => null,
+        ];
+
+        $links = [
+            'first' => [
+                'href' => $first = 'http://localhost/api/v1/posts?' . Arr::query([
+                    'page' => ['limit' => '3']
+                ]),
+            ],
+        ];
+
+        $page = $this->posts->repository()->queryAll()->paginate(['limit' => '3']);
+
+        $this->assertSame(['page' => $meta], $page->meta());
+        $this->assertSame($links, $page->links()->toArray());
+        $this->assertEmpty($page);
+    }
+
+    public function testWithoutCursor(): void
+    {
+        $posts = Post::factory()->count(4)->create();
+
+        $meta = [
+            'from' => 'eyJpZCI6NCwiX3BvaW50c1RvTmV4dEl0ZW1zIjpmYWxzZX0',
+            'hasMore' => true,
+            'perPage' => 3,
+            'to' => 'eyJpZCI6MiwiX3BvaW50c1RvTmV4dEl0ZW1zIjp0cnVlfQ',
+        ];
+
+        $links = [
+            'first' => [
+                'href' => 'http://localhost/api/v1/posts?' . Arr::query([
+                        'page' => ['limit' => '3']
+                    ]),
+            ],
+            'next' => [
+                'href' => 'http://localhost/api/v1/posts?' . Arr::query([
+                        'page' => ['after' => 'eyJpZCI6MiwiX3BvaW50c1RvTmV4dEl0ZW1zIjp0cnVlfQ', 'limit' => '3']
+                    ]),
+            ]
+        ];
+
+        $page = $this->posts->repository()->queryAll()->paginate(['limit' => '3']);
+
+        $this->assertSame(['page' => $meta], $page->meta());
+        $this->assertSame($links, $page->links()->toArray());
+        $this->assertPage($posts->reverse()->take(3), $page);
+    }
+
+    public function testAfter(): void
+    {
+        $posts = Post::factory()->count(4)->create();
+
+        $this->paginator->withCamelCaseMeta();
+
+        $meta = [
+            'from' => 'eyJpZCI6MSwiX3BvaW50c1RvTmV4dEl0ZW1zIjpmYWxzZX0',
+            'hasMore' => false,
+            'perPage' => 3,
+            'to' => 'eyJpZCI6MSwiX3BvaW50c1RvTmV4dEl0ZW1zIjp0cnVlfQ',
+        ];
+
+        $links = [
+            'first' => [
+                'href' => 'http://localhost/api/v1/posts?' . Arr::query([
+                        'page' => ['limit' => '3']
+                    ]),
+            ],
+            'prev' => [
+                'href' => 'http://localhost/api/v1/posts?' . Arr::query([
+                        'page' => ['before' => 'eyJpZCI6MSwiX3BvaW50c1RvTmV4dEl0ZW1zIjpmYWxzZX0', 'limit' => '3']
+                    ]),
+            ],
+        ];
+
+        $page = $this->posts->repository()->queryAll()->paginate(['after' => 'eyJpZCI6MiwiX3BvaW50c1RvTmV4dEl0ZW1zIjp0cnVlfQ', 'limit' => '3']);
+
+        $this->assertSame(['page' => $meta], $page->meta());
+        $this->assertSame($links, $page->links()->toArray());
+        $this->assertPage([$posts->first()], $page);
+    }
+
+    public function testBefore(): void
+    {
+        $posts = Post::factory()->count(4)->create();
+
+        $this->paginator->withCamelCaseMeta();
+
+        $meta = [
+            'from' => 'eyJpZCI6NCwiX3BvaW50c1RvTmV4dEl0ZW1zIjpmYWxzZX0',
+            'hasMore' => true,
+            'perPage' => 3,
+            'to' => 'eyJpZCI6MiwiX3BvaW50c1RvTmV4dEl0ZW1zIjp0cnVlfQ',
+        ];
+
+        $links = [
+            'first' => [
+                'href' => 'http://localhost/api/v1/posts?' . Arr::query([
+                        'page' => ['limit' => '3']
+                    ]),
+            ],
+            'prev' => [
+                'href' => 'http://localhost/api/v1/posts?' . Arr::query([
+                        'page' => ['before' => 'eyJpZCI6NCwiX3BvaW50c1RvTmV4dEl0ZW1zIjpmYWxzZX0', 'limit' => '3']
+                    ]),
+            ],
+        ];
+
+        $page = $this->posts->repository()->queryAll()->paginate(['before' => 'eyJpZCI6MSwiX3BvaW50c1RvTmV4dEl0ZW1zIjpmYWxzZX0', 'limit' => '3']);
+
+        $this->assertSame(['page' => $meta], $page->meta());
+        $this->assertSame($links, $page->links()->toArray());
+        $this->assertPage($posts->reverse()->take(3), $page);
+    }
+
+    /**
+     * When no page size is provided, the default is used from the model.
+     */
+    public function testItUsesModelDefaultPerPage(): void
+    {
+        $expected = (new Post())->getPerPage();
+        $posts = Post::factory()->count($expected + 1)->create();
+
+        $meta = [
+            'from' => 'eyJpZCI6MTYsIl9wb2ludHNUb05leHRJdGVtcyI6ZmFsc2V9',
+            'hasMore' => true,
+            'perPage' => $expected,
+            'to' => 'eyJpZCI6MiwiX3BvaW50c1RvTmV4dEl0ZW1zIjp0cnVlfQ',
+
+        ];
+
+        $links = [
+            'first' => [
+                'href' => 'http://localhost/api/v1/posts?' . Arr::query([
+                    'page' => ['limit' => $expected]
+                ]),
+            ],
+            'next' => [
+                'href' => 'http://localhost/api/v1/posts?' . Arr::query([
+                    'page' => ['after' => 'eyJpZCI6MiwiX3BvaW50c1RvTmV4dEl0ZW1zIjp0cnVlfQ', 'limit' => $expected]
+                ]),
+            ],
+        ];
+
+        $page = $this->posts->repository()->queryAll()->paginate(['number' => '1']);
+
+        $this->assertSame(['page' => $meta], $page->meta());
+        $this->assertSame($links, $page->links()->toArray());
+        $this->assertPage($posts->reverse()->take($expected), $page);
+    }
+
+    /**
+     * The default per-page value can be overridden on the paginator.
+     */
+    public function testItUsesDefaultPerPage(): void
+    {
+        $expected = (new Post())->getPerPage() - 5;
+
+        $this->paginator->withDefaultPerPage($expected);
+
+        $posts = Post::factory()->count($expected + 1)->create();
+
+        $meta = [
+            'from' => 'eyJpZCI6MTEsIl9wb2ludHNUb05leHRJdGVtcyI6ZmFsc2V9',
+            'hasMore' => true,
+            'perPage' => 10,
+            'to' => 'eyJpZCI6MiwiX3BvaW50c1RvTmV4dEl0ZW1zIjp0cnVlfQ',
+        ];
+
+        $links = [
+            'first' => [
+                'href' => 'http://localhost/api/v1/posts?' . Arr::query([
+                        'page' => ['limit' => $expected]
+                    ]),
+            ],
+            'next' => [
+                'href' => 'http://localhost/api/v1/posts?' . Arr::query([
+                        'page' => ['after' => 'eyJpZCI6MiwiX3BvaW50c1RvTmV4dEl0ZW1zIjp0cnVlfQ', 'limit' => $expected]
+                    ]),
+            ],
+        ];
+
+        $page = $this->posts->repository()->queryAll()->paginate(['number' => '1']);
+
+        $this->assertSame(['page' => $meta], $page->meta());
+        $this->assertSame($links, $page->links()->toArray());
+        $this->assertPage($posts->reverse()->take($expected), $page);
+    }
+
+    public function testPageWithReverseKey(): void
+    {
+        $posts = Post::factory()->count(4)->create();
+
+        $page = $this->posts->repository()->queryAll()
+            ->sort('-id')
+            ->paginate(['limit' => '3']);
+
+        $this->assertPage($posts->reverse()->take(3), $page);
+    }
+
+    /**
+     * If we are sorting by a column that might not be unique, we expect
+     * the page to always be returned in a particular order i.e. by the
+     * key column.
+     *
+     * @see https://github.com/cloudcreativity/laravel-json-api/issues/313
+     */
+    public function testDeterministicOrder(): void
+    {
+        $first = Video::factory()->create([
+            'created_at' => Carbon::now()->subWeek(),
+        ]);
+
+        $second = Video::factory()->create([
+            'uuid' => 'f3b3bea3-dca0-4ef9-b06c-43583a7e6118',
+            'created_at' => Carbon::now()->subHour(),
+        ]);
+
+        $third = Video::factory()->create([
+            'uuid' => 'd215f35c-feb7-4cc5-9631-61742f00d0b2',
+            'created_at' => $second->created_at,
+        ]);
+
+        $fourth = Video::factory()->create([
+            'uuid' => 'cbe17134-d7e2-4509-ba2c-3b3b5e3b2cbe',
+            'created_at' => $second->created_at,
+        ]);
+
+        $page = $this->videos->repository()->queryAll()
+            ->sort('createdAt')
+            ->paginate(['limit' => '3']);
+
+        $this->assertPage([$first, $second, $third], $page);
+
+        $page = $this->videos->repository()->queryAll()
+            ->sort('-createdAt')
+            ->paginate(['limit' => '3']);
+
+        $this->assertPage([$second, $third, $fourth], $page);
+    }
+
+    public function testMultipleSorts(): void
+    {
+        $first = Video::factory()->create([
+            'title' => 'b',
+            'created_at' => Carbon::now()->subWeek(),
+        ]);
+
+        $second = Video::factory()->create([
+            'title' => 'a',
+            'uuid' => 'f3b3bea3-dca0-4ef9-b06c-43583a7e6118',
+            'created_at' => Carbon::now()->subHour(),
+        ]);
+
+        $third = Video::factory()->create([
+            'title' => 'b',
+            'uuid' => 'd215f35c-feb7-4cc5-9631-61742f00d0b2',
+            'created_at' => $second->created_at,
+        ]);
+
+        $fourth = Video::factory()->create([
+            'title' => 'a',
+            'uuid' => 'cbe17134-d7e2-4509-ba2c-3b3b5e3b2cbe',
+            'created_at' => $second->created_at,
+        ]);
+
+        $page = $this->videos->repository()->queryAll()
+            ->sort('title,createdAt')
+            ->paginate(['limit' => '3']);
+
+        $this->assertPage([$second, $fourth, $first], $page);
+
+        $page = $this->videos->repository()->queryAll()
+            ->sort('title,-createdAt')
+            ->paginate(['limit' => '3']);
+
+        $this->assertPage([$second, $fourth, $third], $page);
+    }
+
+    public function testWithoutKeySort(): void
+    {
+        $this->paginator->withoutKeySort();
+
+        $first = Video::factory()->create([
+            'title' => 'a',
+        ]);
+
+        $second = Video::factory()->create([
+            'title' => 'a',
+            'uuid' => 'f3b3bea3-dca0-4ef9-b06c-43583a7e6118',
+        ]);
+
+        $third = Video::factory()->create([
+            'title' => 'c',
+            'uuid' => 'd215f35c-feb7-4cc5-9631-61742f00d0b2',
+        ]);
+
+        $fourth = Video::factory()->create([
+            'title' => 'b',
+            'uuid' => 'cbe17134-d7e2-4509-ba2c-3b3b5e3b2cbe',
+        ]);
+
+        $page = $this->videos->repository()->queryAll()
+            ->sort('title')
+            ->paginate(['limit' => '3']);
+
+        $this->assertPage([$first, $second, $fourth], $page);
+
+        $this->paginator->withKeySort();
+
+        $page = $this->videos->repository()->queryAll()
+            ->sort('title')
+            ->paginate(['limit' => '3']);
+
+        $this->assertPage([$second, $first, $fourth], $page);
+
+    }
+
+
+    public function testCustomPageKeys(): void
+    {
+        Post::factory()->count(4)->create();
+
+        $this->paginator->withAfterKey('next')->withBeforeKey('prev')->withLimitKey('perPage');
+
+        $links = [
+            'first' => [
+                'href' => 'http://localhost/api/v1/posts?' . Arr::query([
+                        'page' => ['perPage' => '3']
+                    ]),
+            ],
+            'next' => [
+                'href' => 'http://localhost/api/v1/posts?' . Arr::query([
+                        'page' => ['next' => 'eyJpZCI6MiwiX3BvaW50c1RvTmV4dEl0ZW1zIjp0cnVlfQ', 'perPage' => '3']
+                    ]),
+            ],
+        ];
+
+        $page = $this->posts->repository()->queryAll()->paginate(['perPage' => '3']);
+
+        $this->assertSame($links, $page->links()->toArray());
+
+
+        $links = [
+            'first' => [
+                'href' => 'http://localhost/api/v1/posts?' . Arr::query([
+                        'page' => ['perPage' => '3']
+                    ]),
+            ],
+            'prev' => [
+                'href' => 'http://localhost/api/v1/posts?' . Arr::query([
+                        'page' => ['perPage' => '3', 'prev' => 'eyJpZCI6MSwiX3BvaW50c1RvTmV4dEl0ZW1zIjpmYWxzZX0']
+                    ]),
+            ],
+        ];
+
+        $page = $this->posts->repository()->queryAll()->paginate(['next' => 'eyJpZCI6MiwiX3BvaW50c1RvTmV4dEl0ZW1zIjp0cnVlfQ', 'perPage' => '3']);
+
+        $this->assertSame($links, $page->links()->toArray());
+    }
+
+    public function testSnakeCaseMetaAndCustomMetaKey(): void
+    {
+        $posts = Post::factory()->count(4)->create();
+
+        $this->paginator->withMetaKey('paginator')->withSnakeCaseMeta();
+
+        $meta = [
+            'from' => 'eyJpZCI6NCwiX3BvaW50c1RvTmV4dEl0ZW1zIjpmYWxzZX0',
+            'has_more' => true,
+            'per_page' => 3,
+            'to' => 'eyJpZCI6MiwiX3BvaW50c1RvTmV4dEl0ZW1zIjp0cnVlfQ',
+        ];
+
+        $page = $this->posts->repository()->queryAll()->paginate(['limit' => '3']);
+
+        $this->assertSame(['paginator' => $meta], $page->meta());
+        $this->assertPage($posts->reverse()->take(3), $page);
+    }
+
+    public function testDashCaseMeta(): void
+    {
+        $posts = Post::factory()->count(4)->create();
+
+        $this->paginator->withDashCaseMeta();
+
+        $meta = [
+            'from' => 'eyJpZCI6NCwiX3BvaW50c1RvTmV4dEl0ZW1zIjpmYWxzZX0',
+            'has-more' => true,
+            'per-page' => 3,
+            'to' => 'eyJpZCI6MiwiX3BvaW50c1RvTmV4dEl0ZW1zIjp0cnVlfQ',
+        ];
+
+        $page = $this->posts->repository()->queryAll()->paginate(['limit' => '3']);
+
+        $this->assertSame(['page' => $meta], $page->meta());
+        $this->assertPage($posts->reverse()->take(3), $page);
+    }
+
+    public function testMetaNotNested(): void
+    {
+        $posts = Post::factory()->count(4)->create();
+
+        $this->paginator->withoutNestedMeta();
+
+        $meta = [
+            'from' => 'eyJpZCI6NCwiX3BvaW50c1RvTmV4dEl0ZW1zIjpmYWxzZX0',
+            'hasMore' => true,
+            'perPage' => 3,
+            'to' => 'eyJpZCI6MiwiX3BvaW50c1RvTmV4dEl0ZW1zIjp0cnVlfQ',
+        ];
+
+        $page = $this->posts->repository()->queryAll()->paginate(['limit' => '3']);
+
+        $this->assertSame($meta, $page->meta());
+        $this->assertPage($posts->reverse()->take(3), $page);
+    }
+
+    public function testItCanRemoveMeta(): void
+    {
+        $posts = Post::factory()->count(4)->create();
+
+        $this->paginator->withoutMeta();
+
+        $links = [
+            'first' => [
+                'href' => 'http://localhost/api/v1/posts?' . Arr::query([
+                    'page' => ['limit' => '3']
+                ]),
+            ],
+            'next' => [
+                'href' => 'http://localhost/api/v1/posts?' . Arr::query([
+                    'page' => ['after' => 'eyJpZCI6MiwiX3BvaW50c1RvTmV4dEl0ZW1zIjp0cnVlfQ', 'limit' => '3']
+                ]),
+            ],
+        ];
+
+        $page = $this->posts->repository()->queryAll()->paginate(['limit' => 3]);
+
+        $this->assertEmpty($page->meta());
+        $this->assertSame($links, $page->links()->toArray());
+        $this->assertPage($posts->reverse()->take(3), $page);
+    }
+
+    public function testUrlsIncludeOtherQueryParameters(): void
+    {
+        $posts = Post::factory()->count(6)->create();
+        $slugs = $posts->take(4)->pluck('slug')->implode(',');
+
+        $links = [
+            'first' => [
+                'href' => 'http://localhost/api/v1/posts?' . Arr::query([
+                        'fields' => $fields = [
+                            'posts' => 'author,slug,title',
+                            'users' => 'name',
+                        ],
+                        'filter' => ['slugs' => $slugs],
+                        'include' => 'author',
+                        'page' => ['limit' => '3'],
+                    ]),
+            ],
+            'next' => [
+                'href' => 'http://localhost/api/v1/posts?' . Arr::query([
+                        'fields' => $fields,
+                        'filter' => ['slugs' => $slugs],
+                        'include' => 'author',
+                        'page' => ['after' => 'eyJpZCI6MiwiX3BvaW50c1RvTmV4dEl0ZW1zIjp0cnVlfQ', 'limit' => '3'],
+                    ]),
+            ],
+        ];
+
+        $query = QueryParameters::make()
+            ->setFilters(['slugs' => $slugs])
+            ->setSparseFieldSets($fields)
+            ->setIncludePaths('author');
+
+        $page = $this->posts
+            ->repository()
+            ->queryAll()
+            ->withQuery($query)
+            ->paginate(['limit' => 3]);
+
+        $this->assertSame($links, $page->links()->toArray());
+    }
+
+    public function testWithTotal()
+    {
+        $this->paginator->withTotal();
+
+        $meta = [
+            'from' => 'eyJpZCI6NCwiX3BvaW50c1RvTmV4dEl0ZW1zIjpmYWxzZX0',
+            'hasMore' => true,
+            'perPage' => 3,
+            'to' => 'eyJpZCI6MiwiX3BvaW50c1RvTmV4dEl0ZW1zIjp0cnVlfQ',
+            'total' => 4,
+        ];
+
+        Post::factory()->count(4)->create();
+
+        $page = $this->posts
+            ->repository()
+            ->queryAll()
+            ->paginate(['limit' => 3]);
+
+        $this->assertInstanceOf(Page::class, $page);
+        $this->assertSame(['page' => $meta], $page->meta());
+
+        $page = $this->posts
+            ->repository()
+            ->queryAll()
+            ->paginate(['after' => 'eyJpZCI6MiwiX3BvaW50c1RvTmV4dEl0ZW1zIjp0cnVlfQ', 'limit' => 3]);
+
+        $this->assertInstanceOf(Page::class, $page);
+        $this->assertArrayHasKey('page', $page->meta());
+        $this->assertArrayHasKey('total', $page->meta()['page']);
+        $this->assertEquals(4, $page->meta()['page']['total']);
+
+    }
+
+    public function testWithTotalOnFirstPage()
+    {
+        $this->paginator->withTotalOnFirstPage();
+
+        $meta = [
+            'from' => 'eyJpZCI6NCwiX3BvaW50c1RvTmV4dEl0ZW1zIjpmYWxzZX0',
+            'hasMore' => true,
+            'perPage' => 3,
+            'to' => 'eyJpZCI6MiwiX3BvaW50c1RvTmV4dEl0ZW1zIjp0cnVlfQ',
+            'total' => 4,
+        ];
+
+        Post::factory()->count(4)->create();
+
+        $page = $this->posts
+            ->repository()
+            ->queryAll()
+            ->paginate(['limit' => 3]);
+
+        $this->assertInstanceOf(Page::class, $page);
+        $this->assertSame(['page' => $meta], $page->meta());
+
+        $page = $this->posts
+            ->repository()
+            ->queryAll()
+            ->paginate(['after' => 'eyJpZCI6MiwiX3BvaW50c1RvTmV4dEl0ZW1zIjp0cnVlfQ', 'limit' => 3]);
+
+        $this->assertInstanceOf(Page::class, $page);
+        $this->assertArrayHasKey('page', $page->meta());
+        $this->assertArrayNotHasKey('total', $page->meta()['page']);
+    }
+
+    /**
+     * Assert that the pages match.
+     *
+     * @param $expected
+     * @param $actual
+     */
+    private function assertPage($expected, $actual): void
+    {
+        $expected = (new Collection($expected))->modelKeys();
+        $actual = (new Collection($actual))->modelKeys();
+
+        $this->assertSame(array_values($expected), array_values($actual));
+    }
+
+}

--- a/tests/lib/EncodedId.php
+++ b/tests/lib/EncodedId.php
@@ -1,0 +1,91 @@
+<?php
+/*
+ * Copyright 2024 Cloud Creativity Limited
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE file or at
+ * https://opensource.org/licenses/MIT.
+ */
+
+declare(strict_types=1);
+
+namespace LaravelJsonApi\Eloquent\Tests;
+
+use Illuminate\Support\Str;
+use LaravelJsonApi\Contracts\Schema\ID;
+use LaravelJsonApi\Contracts\Schema\IdEncoder;
+
+class EncodedId implements ID, IdEncoder
+{
+    /**
+     * @inheritDoc
+     */
+    public function name(): string
+    {
+        return 'id';
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function isSparseField(): bool
+    {
+        return false;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function key(): ?string
+    {
+        // TODO: Implement key() method.
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function pattern(): string
+    {
+        return '^TEST-';
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function match(string $value): bool
+    {
+        return 1 === preg_match('/^TEST-/', $value);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function acceptsClientIds(): bool
+    {
+        return false;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function isSortable(): bool
+    {
+        return false;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function encode($modelKey): string
+    {
+        return "TEST-{$modelKey}";
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function decode(string $resourceId)
+    {
+        return Str::after($resourceId, 'TEST-');
+    }
+}


### PR DESCRIPTION
# Cursor Pagination
Adds a Cursor Pagination implementation that uses eloquent's `cursorPaginate` under the hood but maintains the contract from the existing `cursor-pagination` package implementation meaning it should act as a drop-in replacement in most cases.

## Changes to existing CursorPagination API:

### Features
-  **now supports arbitrary sorting**, you freely sort as required either via query params or a default sort or global scopes pagination will still work as expected, your cursors will just be a little longer. With one caveat... see notes below.
 - adds a `withTotal` and `withTotalOnFirstPage` method, this will add a `total` to the page meta that is a count of the total results, the former will do this on any paginated query (with or without a cursor), whereas the later will only do this additional query on the `first page` i.e. when paginating but with no `before` or `after` cursor provided. 

### Breaking
- removes the `withCursorColumn` method, this is no longer necessary as you can sort by any arbitrary column(s).
- **By default the paginator will add a descending sort by the model key** (or provided withKeyName column) to the query to ensure a deterministic order even if no sort is applied. If you **know** your provided sort/order, or default via global scope etc, is deterministic you can turn this off with `withoutKeySort`.
The `withAscending` method will now only affect this default key sort. I.e you can reverse the default applied key sort, but if its disabled with `withoutKeySort` this will do nothing.
If you relied specifically on the default created_at sorting applied when not providing a `withCursorColumn` (with a non sequential monotonic key column, such that the order would actually change) then you will need to explicitly add this as a sort either as a default or via a global scope etc.

### Notes
- will support encoding/decoding the key column using the provided ID class as required but supporting encoding/decoding the values for additional sort columns that cannot reliably be encoded to json in the cursor, for example uuids represented as binary in the DB, would likely involve further thought/work and or some changes to the underlying laravel cursor implementation, this is a limitation there really.
