### PR TITLE
fix: keyName column may not be present in pagination cursor

### DIFF
--- a/src/Pagination/Cursor/CursorParser.php
+++ b/src/Pagination/Cursor/CursorParser.php
@@ -32,12 +32,13 @@ final readonly class CursorParser
      */
     public function encode(LaravelCursor $cursor): string
     {
-        $key = $cursor->parameter($this->keyName);
-
-        if ($key) {
+        try {
+            $key = $cursor->parameter($this->keyName);
             $parameters = $this->withoutPrivate($cursor->toArray());
             $parameters[$this->keyName] = $this->idParser->encode($key);
             $cursor = new LaravelCursor($parameters, $cursor->pointsToNextItems());
+        } catch (\UnexpectedValueException $ex) {
+           // Do nothing as the cursor does not contain the key.
         }
 
         return $cursor->encode();


### PR DESCRIPTION
The laravel cursor `parameter` function throws an exception if the requested key is not present in the cursors' parameters.
However, when using `withoutKeySort()` on your CursorPaginator the key will not be there and we should ignore its absence.