### PR TITLE
feature: add asInteger() as method to DeserializesValue trait

### DIFF
--- a/src/Filters/Concerns/DeserializesValue.php
+++ b/src/Filters/Concerns/DeserializesValue.php
@@ -50,6 +50,20 @@ trait DeserializesValue
     }
 
     /**
+     * Deserialize value as a integer.
+     *
+     * @return $this
+     */
+    public function asInteger(): self
+    {
+        $this->deserializeUsing(
+            static fn($value) => filter_var($value, FILTER_VALIDATE_INT)
+        );
+
+        return $this;
+    }
+
+    /**
      * Deserialize the value.
      *
      * @param mixed $value


### PR DESCRIPTION
This PR is designed for filtering integer data. It is applicable in cases where the server can receive a string argument for the filter in a numeric database field.